### PR TITLE
Add helper for building the fields and expand options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+pocketbase
 
 .env
 

--- a/README.md
+++ b/README.md
@@ -669,6 +669,9 @@ console.log(records);
 >   .fields(['title', 'expand.*'])
 >   .expand(['author', 'comments_via_post'])
 >   .build(pb.filter);
+>
+> console.log(query.fields); // Output: 'title,expand.*'
+> console.log(query.expand); // Output: 'author,comments_via_post'
 > ```
 
 ### Expand Related Records
@@ -679,7 +682,7 @@ _Since v0.3.0_
 
 **_Starter_** - This can only be used once, at the start.
 
-`expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+`expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
 
 Notes:
 - Supports up to 6-levels depth nested relations expansion.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # pb-query 🔍✨
 
-**Build type-safe PocketBase queries with the power of TypeScript.**  
+**Build type-safe PocketBase queries with the power of TypeScript.**
 *Flexible and strongly-typed, with useful helpers to simplify the querying process.*
 
 [![npm](https://img.shields.io/npm/v/@sergio9929/pb-query)](https://www.npmjs.com/package/@sergio9929/pb-query)
@@ -34,6 +34,15 @@ pnpm add @sergio9929/pb-query
 yarn add @sergio9929/pb-query
 ```
 
+## Version Compatibility
+
+You are reading the documentation for versions equal or higher to `pb-query@0.3.0`.
+
+| PocketBase | pb-query | documentation |
+| - | - | - |
+| >= 0.22.0 | >= 0.3.0 | current |
+| >= 0.22.0 | <= 0.2.9 | [read](https://github.com/sergio9929/pb-query/tree/a62a71887a7cb8f6328f35ee6b57480bdf8bfc5f) |
+
 ## Quick Start
 
 ### App
@@ -50,26 +59,37 @@ const pb = new PocketBase("https://example.com");
 
 // Build a type-safe query for posts
 const query = pbQuery<Post>()
+  .fields([
+    'title',
+    'content:excerpt(100,true)',
+    'author',
+    'expand.author.name', // Automatically expanded
+    'expand.comments_via_post', // Automatically expanded
+  ]) // Optional
   .search(['title', 'content', 'tags', 'author'], 'footba')
   .and()
   .between('created', new Date('2023-01-01'), new Date('2023-12-31'))
   .or()
-  .group((q) => 
+  .group((q) =>
     q.anyLike('tags', 'sports')
       .and()
       .greaterThan('priority', 5)
   )
   .build(pb.filter);
 
-console.log(query);
-// (title~'footba' || content~'footba' || tags~'footba' || author~'footba') 
-// && (created>='2023-01-01 00:00:00.000Z' && created<='2023-12-31 00:00:00.000Z') 
-// || (tags?~'sports' && priority>5)
+console.log(query.expand);
+// Output: 'author,comments_via_post'
+
+console.log(query.fields);
+// Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+
+console.log(query.filter);
+// Output: "(title~'footba' || content~'footba' || tags~'footba' || author~'footba')
+// && (created>='2023-01-01 00:00:00.000Z' && created<='2023-12-31 00:00:00.000Z')
+// || (tags?~'sports' && priority>5)"
 
 // Use your query
-const records = await pb.collection("posts").getList(1, 20, {
-  filter: query,
-});
+const records = await pb.collection("posts").getList(1, 20, query);
 ```
 
 > [!IMPORTANT]
@@ -87,7 +107,7 @@ const records = await pb.collection("posts").getList(1, 20, {
 routerAdd("GET", "/example", (e) => {
   const { pbQuery } = require('@sergio9929/pb-query');
 
-  const { raw, values } = pbQuery()
+  const { filter } = pbQuery()
     .search(['title', 'content', 'tags.title', 'author'], 'footba')
     .and()
     .between('created', new Date('2023-01-01'), new Date('2024-12-31'))
@@ -101,11 +121,11 @@ routerAdd("GET", "/example", (e) => {
 
   const records = $app.findRecordsByFilter(
     'posts',
-    raw,
+    filter.raw,
     '',
     20,
     0,
-    values,
+    filter.values,
   );
 
   return e.json(200, records);
@@ -120,8 +140,8 @@ routerAdd("GET", "/example", (e) => {
 - 🧩 [Combination Operators](#combination-operators)
 - 🛠️ [Multiple Operators](#multiple-operators)
 - ⚡ [Helper Operators](#helper-operators)
+- 🔍 [Fields and Expand](#fields-and-expand)
 - 💡 [Tips and Tricks](#tips-and-tricks)
-- 📜 [Real-World Recipes](#real-world-recipes)
 - 🚨 [Troubleshooting](#troubleshooting)
 - 🙏 [Credits](#credits)
 
@@ -159,7 +179,15 @@ const query = pbQuery<Post>()
   .like('content', 'Top Secret%')
   .build();
 
-console.log(query);  // { raw: 'content~{:content1}', values: { content1: 'Top Secret%' } }
+console.log(query);
+// {
+//   fields: '',
+//   expand: '',
+//   filter: {
+//     raw: 'content~{:content1}',
+//     values: { content1: 'Top Secret%' }
+//   }
+// }
 ```
 
 You can use this principle to create dynamic queries:
@@ -180,12 +208,15 @@ By default, we don't filter your query. Using `.build()` returns the unfiltered 
 
 ```ts
 // ❌ Unfiltered query
-const { raw, values } = pbQuery<Post>()
-  .search(['title', 'content', 'tags', 'author.name', 'author.surname'], 'Football')
+const { filter } = pbQuery<Post>()
+  .like('content', 'Top Secret%')
   .build();
 
-console.log(raw);    // "content~{:content1}"
-console.log(values); // { content1: "Top Secret%" }
+console.log(filter);
+// {
+//   raw: 'content~{:content1}',
+//   values: { content1: 'Top Secret%' }
+// }
 ```
 
 We expose a filter function, but we recommend using the native `pb.filter()` function instead.
@@ -197,11 +228,11 @@ import PocketBase from 'pocketbase';
 const pb = new PocketBase("https://example.com");
 
 // ✅ Filtered query
-const query = pbQuery<Post>()
+const { filter } = pbQuery<Post>()
   .like('content', 'Top Secret%')
   .build(pb.filter); // use PocketBase's filter function
 
-console.log(query);  // "content~'Top Secret%'"
+console.log(filter);  // "content~'Top Secret%'"
 ```
 
 ### Key Modifiers
@@ -580,6 +611,105 @@ Matches records where `key` is not null.
 pbQuery<User>().isNotNull('name'); // name!=''
 ```
 
+## Fields and Expand
+
+### Field Selection
+
+#### `.fields(fields)`
+
+_Since v0.3.0_
+
+**_Starter_** - This can only be used once, at the start.
+
+Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+
+Modifiers:
+- `*` – Targets all keys from the specific depth level.
+- `:excerpt(maxLength, withEllipsis?)` – Returns a short plain text version of the field string value.
+
+> [!WARNING]
+> With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+
+```ts
+const query = pbQuery<Post>()
+  .fields([
+    'title',                       // Basic field
+    'content:excerpt(100,true)',   // Field with excerpt modifier
+    'author',                      // Relation ID field
+    'expand.author',               // Expanded relation field
+    'expand.comments_via_post',    // Back-relation expansion
+  ])
+  .build(pb.filter);
+
+console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+console.log(query.expand); // Output: 'author,comments_via_post'
+
+const records = await pb.collection('posts').getList(1, 20, query);
+
+console.log(records);
+// Output:
+// [
+//   {
+//     author: 'authorId',
+//     title: 'Football match this Saturday',
+//     content: 'Lorem ipsum dolor sit amet.',
+//     expand: {
+//       author: {
+//         name: 'John',
+//       },
+//       comments_via_post: [
+//         { ... },
+//       ],
+//     },
+//   },
+// ]
+```
+
+### Expand Related Records
+
+#### `.expand(fields)`
+
+_Since v0.3.0_
+
+**_Starter_** - This can only be used once, at the start.
+
+`expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+
+Notes:
+- Supports up to 6-levels depth nested relations expansion.
+- The expanded relations will be appended to the record under the [`expand`](https://pocketbase.io/docs/working-with-relations/#expanding-relations) property (e.g. `"expand": { "relField1": { ... }, ... }`).
+- Only the relations to which the request user has permissions to view will be expanded.
+
+Read more about [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations) in the [official documentation](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+
+```ts
+const query = pbQuery<Post>()
+  .expand([
+    'author',
+    'comments_via_post',
+  ])
+  .build(pb.filter);
+
+console.log(query.fields); // Output: ''
+console.log(query.expand); // Output: 'author,comments_via_post'
+
+const records = await pb.collection('posts').getList(1, 20, query);
+
+console.log(records);
+// Output:
+// [
+//   {
+//     expand: {
+//       author: { ... },
+//         comments_via_post: [
+//           { ... },
+//         ],
+//       },
+//     ...,
+//   },
+// ]
+```
+
 ## Tips and tricks
 
 ### Typed Query Builders
@@ -609,7 +739,7 @@ You can clone queries to create new query builders with an initial state. This i
 ```ts
 // Create a base query for sports-related posts
 export const querySportsPosts = () => pbQuery<Post>()
-  .anyLike('tags', 'sports') 
+  .anyLike('tags', 'sports')
   .and(); // Initial condition: ags?~'sports' &&
 
 const searchQuery1 = querySportsPosts()
@@ -628,51 +758,6 @@ const searchQuery2 = querySportsPosts()
 1. **Initial State**: When you clone a query, it captures the current state of the query builder, including all conditions and values.
 2. **Independent Instances**: Each cloned query is independent, so modifying one does not affect the others.
 3. **Reusability**: Cloning is ideal for creating reusable query templates that can be extended with additional conditions.
-
-## 📜 Real-World Recipes
-
-### Paginated Admin Dashboard
-
-```ts
-const buildAdminQuery = (
-  searchTerm: string,
-  options: {
-    minLogins: number;
-    roles: string[];
-    statuses: string[];
-  }
-) => pbQuery<User>()
-  .search(['name', 'email', 'department'], searchTerm)
-  .and()
-  .greaterThanOrEqual('loginCount', options.minLogins)
-  .and()
-  .in('role', options.roles)
-  .and()
-  .group((q) => 
-    q.in('status', options.statuses)
-      .or()
-      .isNull('status')
-  )
-  .build(pb.filter);
-```
-
-### E-Commerce Product Filter
-
-```ts
-const productQuery = pbQuery<Product>()
-  .between('price', minPrice, maxPrice)
-  .and()
-  .anyLike('tags', category)
-  .and()
-  .lessThan('stock', 5)
-  .and()
-  .group((q) => 
-    q.equal('color', selectedColor)
-      .or()
-      .isNotNull('customizationOptions')
-  )
-  .build(pb.filter);
-```
 
 ### Dynamic Search Query
 
@@ -698,7 +783,7 @@ const searchQuery = buildSearchQuery('Top Secret', user);
 
 ### Common Issues
 
-**Problem:** Date comparisons not working  
+**Problem:** Date comparisons not working
 **Fix:** Always use Date objects:
 ```ts
 pbQuery<Post>().between('created', new Date('2023-01-01'), new Date());
@@ -706,22 +791,22 @@ pbQuery<Post>().between('created', new Date('2023-01-01'), new Date());
 
 ### Performance Tips
 
-1. **Set Max Depth for TypeScript**  
-    By default, we infer types up to 6 levels deep. You can change this for each query.
+1. **Set Max Depth for TypeScript**
+By default, we infer types up to 6 levels deep. You can change this for each query.
 
-    For example, this is 3 levels deep:
+For example, this is 3 levels deep:
 
-    ```ts
-    // author.info.age
-    ```
+```ts
+// author.info.age
+```
 
-    ```ts
-    pbQuery<Post, 3>()
-      .equal('author.info.age', 30)
-      .and()
-      .like('author.email', '%@example.com');
-    // author.info.age=30 && author.email~'%@example.com'
-    ```
+```ts
+pbQuery<Post, 3>()
+  .equal('author.info.age', 30)
+  .and()
+  .like('author.email', '%@example.com');
+// author.info.age=30 && author.email~'%@example.com'
+```
 
 
 ## Credits
@@ -733,5 +818,3 @@ This project was inspired by [@emresandikci/pocketbase-query](https://github.com
 **@sergio9929/pb-query** is maintained by [@sergio9929](https://github.com/sergio9929) with ❤️
 
 Found a bug? [Open an issue](https://github.com/sergio9929/pb-query/issues)
-
-Want to contribute? [Read our guide](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -627,9 +627,6 @@ Modifiers:
 - `*` – Targets all keys from the specific depth level.
 - `:excerpt(maxLength, withEllipsis?)` – Returns a short plain text version of the field string value.
 
-> [!WARNING]
-> With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
-
 ```ts
 const query = pbQuery<Post>()
   .fields([
@@ -664,6 +661,15 @@ console.log(records);
 //   },
 // ]
 ```
+
+> [!WARNING]
+> With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations), so you must specify it manually.
+> ```ts
+> const query = pbQuery<Post>()
+>   .fields(['title', 'expand.*'])
+>   .expand(['author', 'comments_via_post'])
+>   .build(pb.filter);
+> ```
 
 ### Expand Related Records
 

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ pbQuery<User>().isNotNull('name'); // name!=''
 
 _Since v0.3.0_
 
-**_Starter_** - This can only be used once, at the start.
+**_Starter_**, **_Once_** - This can only be used once, at the start.
 
 Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
 
@@ -680,7 +680,7 @@ console.log(records);
 
 _Since v0.3.0_
 
-**_Starter_** - This can only be used once, at the start.
+**_Starter_**, **_Once_** - This can only be used once, at the start.
 
 `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -168,15 +168,21 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
     const queryBuilderStart: QueryBuilderStart<T, MaxDepth> = {
         ...queryBuilder,
         fields(keys) {
+            if (fields) {
+                console.warn('Overriding previous fields:', fields)
+            }
             fields = generateFields(keys)
-            expand = generateExpand(prepareFieldsForExpand(keys))
+            expand ||= generateExpand(prepareFieldsForExpand(keys))
 
-            return queryBuilder
+            return queryBuilderStart
         },
         expand(keys) {
+            if (expand) {
+                console.warn('Overriding previous expand:', expand)
+            }
             expand = generateExpand(keys)
 
-            return queryBuilder
+            return queryBuilderStart
         },
     }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,6 +5,7 @@ import type {
     PathValue,
     QueryBuilder,
     QueryBuilderStart,
+    QueryResult,
     RawQueryObject,
     RestrictedQueryBuilder,
 } from './types'
@@ -78,21 +79,11 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
         }
     }
 
-    function build(): {
-        filter: RawQueryObject
-        fields: string
-        expand: string
-    }
-    function build(filter: FilterFunction): {
-        filter: string
-        fields: string
-        expand: string
-    }
-    function build(filter?: FilterFunction): {
-        filter: RawQueryObject | string
-        fields: string
-        expand: string
-    } {
+    function build(): QueryResult<RawQueryObject>
+    function build(filter: FilterFunction): QueryResult<string>
+    function build(
+        filter?: FilterFunction,
+    ): QueryResult<RawQueryObject | string> {
         if (typeof filter === 'function') {
             return {
                 expand,

--- a/src/query.ts
+++ b/src/query.ts
@@ -171,8 +171,10 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
             if (fields) {
                 console.warn('Overriding previous fields:', fields)
             }
-            fields = generateFields(keys)
-            expand ||= generateExpand(prepareFieldsForExpand(keys))
+
+            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
+            fields = generateFields(normalizedKeys)
+            expand ||= generateExpand(prepareFieldsForExpand(normalizedKeys))
 
             return queryBuilderStart
         },
@@ -180,7 +182,9 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
             if (expand) {
                 console.warn('Overriding previous expand:', expand)
             }
-            expand = generateExpand(keys)
+
+            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
+            expand = generateExpand(normalizedKeys)
 
             return queryBuilderStart
         },

--- a/src/query.ts
+++ b/src/query.ts
@@ -4,16 +4,24 @@ import type {
     Path,
     PathValue,
     QueryBuilder,
+    QueryBuilderStart,
     RawQueryObject,
     RestrictedQueryBuilder,
 } from './types'
-import { isDateMacro } from './utils'
+import {
+    generateExpand,
+    generateFields,
+    isDateMacro,
+    prepareFieldsForExpand,
+} from './utils'
 
-export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilder<
+export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
     T,
     MaxDepth
 > {
     let query = ''
+    let fields = ''
+    let expand = ''
 
     const keyCounter = new Map<Path<T, MaxDepth>, number>()
     const valueMap = new Map<string, unknown>()
@@ -70,13 +78,33 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilder<
         }
     }
 
-    function build(): RawQueryObject
-    function build(filter: FilterFunction): string
-    function build(filter?: FilterFunction): RawQueryObject | string {
+    function build(): {
+        filter: RawQueryObject
+        fields: string
+        expand: string
+    }
+    function build(filter: FilterFunction): {
+        filter: string
+        fields: string
+        expand: string
+    }
+    function build(filter?: FilterFunction): {
+        filter: RawQueryObject | string
+        fields: string
+        expand: string
+    } {
         if (typeof filter === 'function') {
-            return filter(query, Object.fromEntries(valueMap))
+            return {
+                expand,
+                fields,
+                filter: filter(query, Object.fromEntries(valueMap)),
+            }
         }
-        return { raw: query, values: Object.fromEntries(valueMap) }
+        return {
+            expand,
+            fields,
+            filter: { raw: query, values: Object.fromEntries(valueMap) },
+        }
     }
 
     const queryBuilder: QueryBuilder<T, MaxDepth> = {
@@ -146,6 +174,21 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilder<
         build,
     }
 
+    const queryBuilderStart: QueryBuilderStart<T, MaxDepth> = {
+        ...queryBuilder,
+        fields(keys) {
+            fields = generateFields(keys)
+            expand = generateExpand(prepareFieldsForExpand(keys))
+
+            return queryBuilder
+        },
+        expand(keys) {
+            expand = generateExpand(keys)
+
+            return queryBuilder
+        },
+    }
+
     const restrictedQueryBuilder: RestrictedQueryBuilder<T, MaxDepth> = {
         and() {
             query += ' && '
@@ -158,5 +201,5 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilder<
         build,
     }
 
-    return queryBuilder
+    return queryBuilderStart
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,12 @@ export type RawQueryObject = { raw: string; values: Record<string, unknown> }
 
 export type GeoPoint = { lon: string; lat: string }
 
+type Exact<T, U, Y = unknown, N = never> = (<G>() => G extends T
+    ? 1
+    : 2) extends <G>() => G extends U ? 1 : 2
+    ? Y
+    : N
+
 type DepthCounter = [1, 2, 3, 4, 5, 6, never]
 
 export type Path<
@@ -79,13 +85,15 @@ type KeyPathsExpand<
         ? never
         : T[K] extends Date
           ? never
-          : T[K] extends object
-            ?
-                  | `${K}`
-                  | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-                  | `${string}_via_${string}`
-                  | `${string}_via_${string}.${string}`
-            : never
+          : Exact<T[K], GeoPoint, 1, 2> extends 1
+            ? never
+            : T[K] extends object
+              ?
+                    | `${K}`
+                    | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                    | `${string}_via_${string}`
+                    | `${string}_via_${string}.${string}`
+              : never
 
 export type PathFields<
     T,
@@ -117,15 +125,19 @@ type KeyPathsFields<
         ? `${K}`
         : T[K] extends Date
           ? `${K}`
-          : T[K] extends object
+          : Exact<T[K], GeoPoint, 1, 2> extends 1
             ?
                   | `${K}`
-                  | `expand.${K}`
-                  | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-                  | `${string}_via_${string}`
-                  | `expand.${string}_via_${string}`
-                  | `expand.${string}_via_${string}.${string}`
-            : `${K}`
+                  | `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+            : T[K] extends object
+              ?
+                    | `${K}`
+                    | `expand.${K}`
+                    | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                    | `${string}_via_${string}`
+                    | `expand.${string}_via_${string}`
+                    | `expand.${string}_via_${string}.${string}`
+              : `${K}`
 
 type PathValueHelper<
     T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,8 +195,17 @@ export type HandleModifier<V, Modifier extends string> = Modifier extends 'each'
         ? string
         : never
 
-export interface QueryBuilderStart<T, MaxDepth extends number = 6>
-    extends QueryBuilder<T, MaxDepth> {
+export type QueryBuilderStart<
+    T,
+    MaxDepth extends number = 6,
+    Ex extends keyof QueryBuilderStartReal<T, MaxDepth> | '' = '',
+> = Omit<QueryBuilderStartReal<T, MaxDepth, Ex>, Ex>
+
+interface QueryBuilderStartReal<
+    T,
+    MaxDepth extends number = 6,
+    Ex extends keyof QueryBuilderStartReal<T, MaxDepth> | '' = '',
+> extends QueryBuilder<T, MaxDepth> {
     /**
      * **_Starter_** - This can only be used once, at the start.
      *
@@ -244,7 +253,9 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      *
      * @since 0.3.0
      */
-    fields(keys: PathFields<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
+    fields<P extends PathFields<T, MaxDepth>[]>(
+        keys: P,
+    ): QueryBuilderStart<T, MaxDepth, Ex | 'fields'>
 
     /**
      * **_Starter_** - This can only be used once, at the start.
@@ -289,7 +300,9 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      *
      * @since 0.3.0
      */
-    expand(keys: PathExpand<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
+    expand<P extends PathExpand<T, MaxDepth>[]>(
+        keys: P,
+    ): QueryBuilderStart<T, MaxDepth, Ex | 'expand'>
 }
 
 export interface QueryBuilder<T, MaxDepth extends number = 6>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type DatetimeMacro = (typeof DATETIME_MACROS)[number]
 
 export type RawQueryObject = { raw: string; values: Record<string, unknown> }
 
+export type GeoPoint = { lon: string; lat: string }
+
 type DepthCounter = [1, 2, 3, 4, 5, 6, never]
 
 export type Path<
@@ -37,6 +39,7 @@ type KeyPaths<
             | `${K}:each`
             | `${K}:length`
             | `${K}.${Path<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
+            | `${string}_via_${string}.${string}`
       : T[K] extends readonly unknown[]
         ? `${K}` | `${K}:each` | `${K}:length`
         : T[K] extends Date
@@ -46,6 +49,82 @@ type KeyPaths<
                   | `${K}`
                   | `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
                   | `${string}_via_${string}.${string}`
+            : `${K}`
+
+export type PathExpand<
+    T,
+    MaxDepth extends number,
+    K extends keyof T = keyof T,
+    D extends number = 0,
+> = D extends MaxDepth
+    ? never
+    : K extends string // This filters out symbol keys
+      ? KeyPathsExpand<T, K, MaxDepth, D> // Now K is guaranteed to be string key
+      : never
+
+type KeyPathsExpand<
+    T,
+    K extends string & keyof T,
+    MaxDepth extends number,
+    D extends number,
+> = T[K] extends string
+    ? never
+    : T[K] extends readonly object[]
+      ?
+            | `${K}`
+            | `${K}.${PathExpand<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
+            | `${string}_via_${string}`
+            | `${string}_via_${string}.${string}`
+      : T[K] extends readonly unknown[]
+        ? never
+        : T[K] extends Date
+          ? never
+          : T[K] extends object
+            ?
+                  | `${K}`
+                  | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                  | `${string}_via_${string}`
+                  | `${string}_via_${string}.${string}`
+            : never
+
+export type PathFields<
+    T,
+    MaxDepth extends number,
+    K extends keyof T = keyof T,
+    D extends number = 0,
+> = D extends MaxDepth
+    ? never
+    : K extends string // This filters out symbol keys
+      ? KeyPathsFields<T, K, MaxDepth, D> // Now K is guaranteed to be string key
+      : never
+
+type KeyPathsFields<
+    T,
+    K extends string & keyof T,
+    MaxDepth extends number,
+    D extends number,
+> = T[K] extends string
+    ? `${K}`
+    : T[K] extends readonly object[]
+      ?
+            | `${K}`
+            | `expand.${K}`
+            | `expand.${K}.${PathFields<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
+            | `${string}_via_${string}`
+            | `expand.${string}_via_${string}`
+            | `expand.${string}_via_${string}.${string}`
+      : T[K] extends readonly unknown[]
+        ? `${K}`
+        : T[K] extends Date
+          ? `${K}`
+          : T[K] extends object
+            ?
+                  | `${K}`
+                  | `expand.${K}`
+                  | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                  | `${string}_via_${string}`
+                  | `expand.${string}_via_${string}`
+                  | `expand.${string}_via_${string}.${string}`
             : `${K}`
 
 type PathValueHelper<
@@ -94,9 +173,40 @@ export type HandleModifier<V, Modifier extends string> = Modifier extends 'each'
         ? string
         : never
 
+export interface QueryBuilderStart<T, MaxDepth extends number = 6>
+    extends QueryBuilder<T, MaxDepth> {
+    /**
+     * Matches records where `key` equals `value`.
+     *
+     * @example
+     * pbQuery<Post>().select([
+     *     'title',
+     *     'author.email',
+     *     'author.name',
+     *     'author.profilePicture',
+     * ]); // 'title, author.email, author.name, author.profilePicture'
+     *
+     * @example
+     * pbQuery<Post>().select([
+     *     'title',
+     *     { author: ['email', 'name', 'profilePicture'] },
+     * ]); // 'title, author.email, author.name, author.profilePicture'
+     */
+    fields(keys: PathFields<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
+
+    /**
+     * `expand()` is not needed if `select()`, we automatically include what to expand.
+     *
+     * @example
+     * pbQuery<Post>().expand(['author', 'comments_via_postId']); // 'author, comments_via_postId'
+     */
+    expand(keys: PathExpand<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
+}
+
 export interface QueryBuilder<T, MaxDepth extends number = 6> {
     /**
      * Matches records where `key` equals `value`.
+     *
      * @example
      * pbQuery<Post>().equal('author.name', 'Alice'); // name='Alice'
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
@@ -109,6 +219,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
 
     /**
      * Matches records where `key` is not equal to `value`.
+     *
      * @example
      * pbQuery<Post>().notEqual('author.name', 'Alice'); // name!='Alice'
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
@@ -123,6 +234,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is greater than `value`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().greaterThan('age', 21); // age>21
      * pbQuery<User>().greaterThan('created', new Date('2021-01-01')); // created>'2021-01-01 00:00:00.000Z'
@@ -136,6 +248,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is greater than or equal to `value`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().greaterThanOrEqual('age', 18); // age>=18
      * pbQuery<User>().greaterThanOrEqual('created', new Date('2021-01-01')); // created>='2021-01-01 00:00:00.000Z'
@@ -149,6 +262,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is less than `value`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().lessThan('age', 50); // age<50
      * pbQuery<User>().lessThan('created', new Date('2021-01-01')); // created<'2021-01-01 00:00:00.000Z'
@@ -162,6 +276,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is less than or equal to `value`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().lessThanOrEqual('age', 65); // age<=65
      * pbQuery<User>().lessThanOrEqual('created', new Date('2021-01-01')); // created<='2021-01-01 00:00:00.000Z'
@@ -221,6 +336,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` equals `value`.
+     *
      * @example
      * pbQuery<Book>().anyEqual('books_via_author.title', 'The Island'); // post_via_author.name?='The Island'
      *
@@ -236,6 +352,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` is not equal to `value`.
+     *
      * @example
      * pbQuery<Book>().anyNotEqual('books_via_author.title', 'The Island'); // post_via_author.name?!='The Island'
      *
@@ -251,7 +368,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` is greater than `value`.
-     * @example pbQuery<User>().anyGreaterThan('age', 21); // age?>21
+     *
+     * @example
+     * pbQuery<User>().anyGreaterThan('age', 21); // age?>21
      */
     anyGreaterThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -262,7 +381,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` is greater than or equal to `value`.
-     * @example pbQuery<User>().anyGreaterThanOrEqual('age', 18); // age?>=18
+     *
+     * @example
+     * pbQuery<User>().anyGreaterThanOrEqual('age', 18); // age?>=18
      */
     anyGreaterThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -273,7 +394,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` is less than `value`.
-     * @example pbQuery<User>().anyLessThan('age', 50); // age?<50
+     *
+     * @example
+     * pbQuery<User>().anyLessThan('age', 50); // age?<50
      */
     anyLessThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -284,7 +407,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
      *
      * Matches records where at least one of the values in the given `key` is less than or equal to `value`.
-     * @example pbQuery<User>().anyLessThanOrEqual('age', 65); // age?<=65
+     *
+     * @example
+     * pbQuery<User>().anyLessThanOrEqual('age', 65); // age?<=65
      */
     anyLessThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -376,7 +501,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * **_Helper_**
      *
      * Matches records where `key` is in `values`.
-     * @example pbQuery<Post>().in('id', ['id_1', 'id_2', 'id_3']); // (id='id_1' || id='id_2' || id='id_3')
+     *
+     * @example
+     * pbQuery<Post>().in('id', ['id_1', 'id_2', 'id_3']); // (id='id_1' || id='id_2' || id='id_3')
      */
     in<P extends Path<T, MaxDepth>>(
         key: P,
@@ -387,7 +514,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * **_Helper_**
      *
      * Matches records where `key` is not in `values`.
-     * @example pbQuery<User>().notIn('age', [18, 21, 30]); // (age!=18 && age!=21 && age!=30)
+     *
+     * @example
+     * pbQuery<User>().notIn('age', [18, 21, 30]); // (age!=18 && age!=21 && age!=30)
      */
     notIn<P extends Path<T, MaxDepth>>(
         key: P,
@@ -400,6 +529,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is between `from` and `to`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().between('age', 18, 30); // (age>=18 && age<=30)
      * pbQuery<User>().between('created', new Date('2021-01-01'), '@now'); // (created>='2021-01-01 00:00:00.000Z' && created<=@now)
@@ -416,6 +546,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * Matches records where `key` is not between `from` and `to`.
      *
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
+     *
      * @example
      * pbQuery<User>().notBetween('age', 18, 30); // (age<18 || age>30)
      * pbQuery<User>().notBetween('created', new Date('2021-01-01'), '@yesterday'); // (created<'2021-01-01 00:00:00.000Z' || created>@yesterday)
@@ -430,7 +561,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * **_Helper_**
      *
      * Matches records where `key` is null.
-     * @example pbQuery<User>().isNull('name'); // name=''
+     *
+     * @example
+     * pbQuery<User>().isNull('name'); // name=''
      */
     isNull<P extends Path<T, MaxDepth>>(
         key: P,
@@ -440,7 +573,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * **_Helper_**
      *
      * Matches records where `key` is not null.
-     * @example pbQuery<User>().isNotNull('name'); // name!=''
+     *
+     * @example
+     * pbQuery<User>().isNotNull('name'); // name!=''
      */
     isNotNull<P extends Path<T, MaxDepth>>(
         key: P,
@@ -465,7 +600,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
 
     /**
      * Creates a logical group.
-     * @example pbQuery<Post>().group((q) => q.equal('status', 'active').or().equal('status', 'inactive')); // (status~'active' || status~'inactive')
+     *
+     * @example
+     * pbQuery<Post>().group((q) => q.equal('status', 'active').or().equal('status', 'inactive')); // (status~'active' || status~'inactive')
      */
     group(
         callback: (
@@ -475,6 +612,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
 
     /**
      * Returns the query string and values.
+     *
      * @example
      * // We recommend using Pocketbase's native `pb.filter()` function
      * const query = pbQuery<User>().equal('name', 'Alice').build(pb.filter);
@@ -485,27 +623,42 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      * console.log(query.values); // { name: 'Alice' }
      * console.log(pb.filter(query.raw, query.values)); // name='Alice'
      */
-    build(): { raw: string; values: Record<string, unknown> }
-    build(filter: FilterFunction): string
-    build(
-        filter?: FilterFunction,
-    ): { raw: string; values: Record<string, unknown> } | string
+    build(): {
+        filter: { raw: string; values: Record<string, unknown> }
+        fields: string
+        expand: string
+    }
+    build(filter: FilterFunction): {
+        filter: string
+        fields: string
+        expand: string
+    }
+    build(filter?: FilterFunction): {
+        filter: { raw: string; values: Record<string, unknown> } | string
+        fields: string
+        expand: string
+    }
 }
 
 export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6> {
     /**
      * Combines the previous and the next conditions with an `and` logical operator.
-     * @example pbQuery<User>().equal('name', 'Alice').and().equal('role', 'admin'); // name='Alice' && role='admin'
+     *
+     * @example
+     * pbQuery<User>().equal('name', 'Alice').and().equal('role', 'admin'); // name='Alice' && role='admin'
      */
     and(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
     /**
      * Combines the previous and the next conditions with an `or` logical operator.
-     * @example pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
+     *
+     * @example
+     * pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
      */
     or(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
 
     /**
      * Returns the query string and values.
+     *
      * @example
      * // We recommend using Pocketbase's native `pb.filter()` function
      * const query = pbQuery<User>().equal('name', 'Alice').build(pb.filter);
@@ -516,9 +669,19 @@ export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6> {
      * console.log(query.values); // { name: 'Alice' }
      * console.log(pb.filter(query.raw, query.values)); // name='Alice'
      */
-    build(): { raw: string; values: Record<string, unknown> }
-    build(filter: FilterFunction): string
-    build(
-        filter?: FilterFunction,
-    ): { raw: string; values: Record<string, unknown> } | string
+    build(): {
+        filter: RawQueryObject
+        fields: string
+        expand: string
+    }
+    build(filter: FilterFunction): {
+        filter: string
+        fields: string
+        expand: string
+    }
+    build(filter?: FilterFunction): {
+        filter: RawQueryObject | string
+        fields: string
+        expand: string
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,8 +260,8 @@ export interface QueryBuilderStart<
      *
      * @since 0.3.0
      */
-    fields<P extends PathFields<T, MaxDepth>[]>(
-        keys: P,
+    fields<P extends PathFields<T, MaxDepth>>(
+        keys: P | P[],
     ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'fields'>, Once | 'fields'>
 
     /**
@@ -307,8 +307,8 @@ export interface QueryBuilderStart<
      *
      * @since 0.3.0
      */
-    expand<P extends PathExpand<T, MaxDepth>[]>(
-        keys: P,
+    expand<P extends PathExpand<T, MaxDepth>>(
+        keys: P | P[],
     ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'expand'>, Once | 'expand'>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,24 +207,23 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      * - `:excerpt(maxLength, withEllipsis?)` returns a short plain text version of the field string value.
      *
      * @example
+     * ```ts
      * const query = pbQuery<Post>()
      *     .fields([
-     *         'title',
-     *         'content:excerpt(100,true)',
-     *         'author', // Be aware that `author` is not the same as `expand.author`.
-     *         'expand.author.name',
-     *         'expand.comments_via_post',
+     *         'title',                       // Basic field
+     *         'content:excerpt(100,true)',   // Field with excerpt modifier
+     *         'author',                      // Relation ID field
+     *         'expand.author',               // Expanded relation field
+     *         'expand.comments_via_post',    // Back-relation expansion
      *     ])
-     *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
-     *     .build(pb.filter)
+     *     .build(pb.filter);
      *
-     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
-     * console.log(query.fields) // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
-     * console.log(query.expand) // Output: 'author,comments_via_post'
+     * console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+     * console.log(query.expand); // Output: 'author,comments_via_post'
      *
-     * const records = await pb.collection('posts').getList(1, 20, query)
+     * const records = await pb.collection('posts').getList(1, 20, query);
      *
-     * console.log(records)
+     * console.log(records);
      * // Output:
      * // [
      * //     {
@@ -241,6 +240,9 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      * //         },
      * //     },
      * // ]
+     * ```
+     *
+     * @since 0.3.0
      */
     fields(keys: PathFields<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
 
@@ -257,24 +259,20 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      * Read more about [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations) in the [official documentation](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
      *
      * @example
+     * ```ts
      * const query = pbQuery<Post>()
-     *     .fields([
-     *         'title',
-     *         'content:excerpt(100,true)',
-     *         'author', // Be aware that `author` is not the same as `expand.author`.
-     *         'expand.author.name',
-     *         'expand.comments_via_post',
+     *     .expand([
+     *         'author',
+     *         'comments_via_post',
      *     ])
-     *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
-     *     .build(pb.filter)
+     *     .build(pb.filter);
      *
-     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
-     * console.log(query.fields) // Output: ''
-     * console.log(query.expand) // Output: 'author,comments_via_post'
+     * console.log(query.fields); // Output: ''
+     * console.log(query.expand); // Output: 'author,comments_via_post'
      *
-     * const records = await pb.collection('posts').getList(1, 20, query)
+     * const records = await pb.collection('posts').getList(1, 20, query);
      *
-     * console.log(records)
+     * console.log(records);
      * // Output:
      * // [
      * //     {
@@ -287,6 +285,9 @@ export interface QueryBuilderStart<T, MaxDepth extends number = 6>
      * //         ...,
      * //     },
      * // ]
+     * ```
+     *
+     * @since 0.3.0
      */
     expand(keys: PathExpand<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
 }
@@ -297,9 +298,11 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` equals `value`.
      *
      * @example
+     * ```ts
      * pbQuery<Post>().equal('author.name', 'Alice'); // name='Alice'
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
      * pbQuery<Post>().equal('author.name:lower', 'alice'); // name:lower='alice'
+     * ```
      */
     equal<P extends Path<T, MaxDepth>>(
         key: P,
@@ -310,9 +313,11 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` is not equal to `value`.
      *
      * @example
+     * ```ts
      * pbQuery<Post>().notEqual('author.name', 'Alice'); // name!='Alice'
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
      * pbQuery<Post>().notEqual('author.name:lower', 'alice'); // name:lower!='alice'
+     * ```
      */
     notEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -325,8 +330,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().greaterThan('age', 21); // age>21
      * pbQuery<User>().greaterThan('created', new Date('2021-01-01')); // created>'2021-01-01 00:00:00.000Z'
+     * ```
      */
     greaterThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -339,8 +346,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().greaterThanOrEqual('age', 18); // age>=18
      * pbQuery<User>().greaterThanOrEqual('created', new Date('2021-01-01')); // created>='2021-01-01 00:00:00.000Z'
+     * ```
      */
     greaterThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -353,8 +362,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().lessThan('age', 50); // age<50
      * pbQuery<User>().lessThan('created', new Date('2021-01-01')); // created<'2021-01-01 00:00:00.000Z'
+     * ```
      */
     lessThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -367,8 +378,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().lessThanOrEqual('age', 65); // age<=65
      * pbQuery<User>().lessThanOrEqual('created', new Date('2021-01-01')); // created<='2021-01-01 00:00:00.000Z'
+     * ```
      */
     lessThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -380,18 +393,21 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      *
      * It is case-insensitive, so the `:lower` [modifier](https://pocketbase.io/docs/api-rules-and-filters/#special-identifiers-and-modifiers) is unnecessary.
      *
-     * @example
-     * // Contains
+     * @example Contains
+     * ```ts
      * pbQuery<Post>().like('author.name', 'Joh'); // name~'Joh' / name~'%Joh%'
      * // If not specified, auto-wraps the value in `%` for wildcard matching.
+     * ```
      *
-     * @example
-     * // Starts with
+     * @example Starts with
+     * ```ts
      * pbQuery<Post>().like('author.name', 'Joh%'); // name~'Joh%'
+     * ```
      *
-     * @example
-     * // Ends with
+     * @example Ends with
+     * ```ts
      * pbQuery<Post>().like('author.name', '%Doe'); // name~'%Doe'
+     * ```
      */
     like<P extends Path<T, MaxDepth>>(
         key: P,
@@ -403,18 +419,21 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      *
      * It is case-insensitive, so the `:lower` [modifier](https://pocketbase.io/docs/api-rules-and-filters/#special-identifiers-and-modifiers) is unnecessary.
      *
-     * @example
-     * // Doesn't contain
+     * @example Doesn't contain
+     * ```ts
      * pbQuery<Post>().notLike('author.name', 'Joh'); // name!~'Joh' / name!~'%Joh%'
      * // If not specified, auto-wraps the value in `%` for wildcard matching.
+     * ```
      *
-     * @example
-     * // Doesn't start with
+     * @example Doesn't start with
+     * ```ts
      * pbQuery<Post>().notLike('author.name', 'Joh%'); // name!~'Joh%'
+     * ```
      *
-     * @example
-     * // Doesn't end with
+     * @example Doesn't end with
+     * ```ts
      * pbQuery<Post>().notLike('author.name', '%Doe'); // name!~'%Doe'
+     * ```
      */
     notLike<P extends Path<T, MaxDepth>>(
         key: P,
@@ -427,10 +446,12 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` equals `value`.
      *
      * @example
+     * ```ts
      * pbQuery<Book>().anyEqual('books_via_author.title', 'The Island'); // post_via_author.name?='The Island'
      *
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
      * pbQuery<Book>().anyEqual('books_via_author.title:lower', 'the island'); // post_via_author.name:lower?='the island'
+     * ```
      */
     anyEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -443,10 +464,12 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` is not equal to `value`.
      *
      * @example
+     * ```ts
      * pbQuery<Book>().anyNotEqual('books_via_author.title', 'The Island'); // post_via_author.name?!='The Island'
      *
      * // This is case-sensitive. Use the `:lower` modifier for case-insensitive matching.
      * pbQuery<Book>().anyNotEqual('books_via_author.title:lower', 'the island'); // post_via_author.name:lower?!='the island'
+     * ```
      */
     anyNotEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -459,7 +482,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` is greater than `value`.
      *
      * @example
+     * ```ts
      * pbQuery<User>().anyGreaterThan('age', 21); // age?>21
+     * ```
      */
     anyGreaterThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -472,7 +497,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` is greater than or equal to `value`.
      *
      * @example
+     * ```ts
      * pbQuery<User>().anyGreaterThanOrEqual('age', 18); // age?>=18
+     * ```
      */
     anyGreaterThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -485,7 +512,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` is less than `value`.
      *
      * @example
+     * ```ts
      * pbQuery<User>().anyLessThan('age', 50); // age?<50
+     * ```
      */
     anyLessThan<P extends Path<T, MaxDepth>>(
         key: P,
@@ -498,7 +527,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where at least one of the values in the given `key` is less than or equal to `value`.
      *
      * @example
+     * ```ts
      * pbQuery<User>().anyLessThanOrEqual('age', 65); // age?<=65
+     * ```
      */
     anyLessThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
@@ -512,18 +543,21 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      *
      * It is case-insensitive, so the `:lower` [modifier](https://pocketbase.io/docs/api-rules-and-filters/#special-identifiers-and-modifiers) is unnecessary.
      *
-     * @example
-     * // Contains
+     * @example Contains
+     * ```ts
      * pbQuery<Post>().anyLike('author.name', 'Joh'); // name?~'Joh' / name?~'%Joh%'
      * // If not specified, auto-wraps the value in `%` for wildcard matching.
+     * ```
      *
-     * @example
-     * // Starts with
+     * @example Starts with
+     * ```ts
      * pbQuery<Post>().anyLike('author.name', 'Joh%'); // name?~'Joh%'
+     * ```
      *
-     * @example
-     * // Ends with
+     * @example Ends with
+     * ```ts
      * pbQuery<Post>().anyLike('author.name', '%Doe'); // name?~'%Doe'
+     * ```
      */
     anyLike<P extends Path<T, MaxDepth>>(
         key: P,
@@ -537,18 +571,21 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      *
      * It is case-insensitive, so the `:lower` [modifier](https://pocketbase.io/docs/api-rules-and-filters/#special-identifiers-and-modifiers) is unnecessary.
      *
-     * @example
-     * // Doesn't contain
+     * @example Doesn't contain
+     * ```ts
      * pbQuery<Post>().anyNotLike('author.name', 'Joh'); // name?!~'Joh' / name?!~'%Joh%'
      * // If not specified, auto-wraps the value in `%` for wildcard matching.
+     * ```
      *
-     * @example
-     * // Doesn't start with
+     * @example Doesn't start with
+     * ```ts
      * pbQuery<Post>().anyNotLike('author.name', 'Joh%'); // name?!~'Joh%'
+     * ```
      *
-     * @example
-     * // Doesn't end with
+     * @example Doesn't end with
+     * ```ts
      * pbQuery<Post>().anyNotLike('author.name', '%Doe'); // name?!~'%Doe'
+     * ```
      */
     anyNotLike<P extends Path<T, MaxDepth>>(
         key: P,
@@ -564,22 +601,25 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      *
      * It is case-insensitive, so the `:lower` [modifier](https://pocketbase.io/docs/api-rules-and-filters/#special-identifiers-and-modifiers) is unnecessary.
      *
-     * @example
-     * // Full text search
+     * @example Full text search
+     * ```ts
      * pbQuery<Post>().search(['title', 'content', 'tags', 'author.name'], 'Football'); // (title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')
+     * ```
      *
-     * @example
-     * // Contains
-     * pbQuery<User>().search(['name', 'surname'], 'Joh'); // (name~'Joh' || surname~'Joh') / (name~'%Joh%' || surname~'%Joh%')
-     * // If not specified, auto-wraps the value in `%` for wildcard matching.
+     * @example Contains
+     * ```ts
+     * pbQuery<User>().search(['name', 'surname'], 'Joh'); // (name~'Joh' || surname~'Joh') / (name~'%Joh%' || surname~'%Joh%') If not specified, auto-wraps the value in `%` for wildcard matching.
+     * ```
      *
-     * @example
-     * // Starts with
+     * @example Starts with
+     * ```ts
      * pbQuery<User>().search(['name', 'surname'], 'Joh%'); // (name~'Joh%' || surname~'Joh%')
+     * ```
      *
-     * @example
-     * // Ends with
+     * @example Ends with
+     * ```ts
      * pbQuery<User>().search(['name', 'surname'], '%Doe'); // (name~'%Doe' || surname~'%Doe')
+     * ```
      */
     search<P extends Path<T, MaxDepth>>(
         keys: P[],
@@ -592,7 +632,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` is in `values`.
      *
      * @example
+     * ```ts
      * pbQuery<Post>().in('id', ['id_1', 'id_2', 'id_3']); // (id='id_1' || id='id_2' || id='id_3')
+     * ```
      */
     in<P extends Path<T, MaxDepth>>(
         key: P,
@@ -605,7 +647,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` is not in `values`.
      *
      * @example
+     * ```ts
      * pbQuery<User>().notIn('age', [18, 21, 30]); // (age!=18 && age!=21 && age!=30)
+     * ```
      */
     notIn<P extends Path<T, MaxDepth>>(
         key: P,
@@ -620,8 +664,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().between('age', 18, 30); // (age>=18 && age<=30)
      * pbQuery<User>().between('created', new Date('2021-01-01'), '@now'); // (created>='2021-01-01 00:00:00.000Z' && created<=@now)
+     * ```
      */
     between<P extends Path<T, MaxDepth>>(
         key: P,
@@ -637,8 +683,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * [PocketBase's datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) could be helpful when comparing dates: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`, [more...](https://pocketbase.io/docs/api-rules-and-filters/#-macros)
      *
      * @example
+     * ```ts
      * pbQuery<User>().notBetween('age', 18, 30); // (age<18 || age>30)
      * pbQuery<User>().notBetween('created', new Date('2021-01-01'), '@yesterday'); // (created<'2021-01-01 00:00:00.000Z' || created>@yesterday)
+     * ```
      */
     notBetween<P extends Path<T, MaxDepth>>(
         key: P,
@@ -652,7 +700,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` is null.
      *
      * @example
+     * ```ts
      * pbQuery<User>().isNull('name'); // name=''
+     * ```
      */
     isNull<P extends Path<T, MaxDepth>>(
         key: P,
@@ -664,7 +714,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Matches records where `key` is not null.
      *
      * @example
+     * ```ts
      * pbQuery<User>().isNotNull('name'); // name!=''
+     * ```
      */
     isNotNull<P extends Path<T, MaxDepth>>(
         key: P,
@@ -680,10 +732,12 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * If you have a special use case that might be useful to other developers, consider [opening an issue](https://github.com/sergio9929/pb-query/issues), and we may implement it as a new _helper_ in the future.
      *
      * @example
-     * pbQuery<User>().custom('age > 21'); // age > 21
+     * ```ts
+     * pbQuery<User>().custom('geoDistance(address.lon, address.lat, 23.32, 42.69) < 25'); // geoDistance(address.lon, address.lat, 23.32, 42.69) < 25
      *
      * // We recommend using Pocketbase's native `pb.filter()` function
-     * pbQuery<User>().custom(pb.filter('age > {:age}', { age: 21 })); // age > 21
+     * pbQuery<User>().custom(pb.filter('geoDistance(address.lon, address.lat, {:lon}, {:lat}) < {:distance}', { lon: 23.32, lat: 42.69, distance: 25 })); // geoDistance(address.lon, address.lat, 23.32, 42.69) < 25
+     * ```
      */
     custom(raw: string): RestrictedQueryBuilder<T, MaxDepth>
 
@@ -691,7 +745,9 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * Creates a logical group.
      *
      * @example
+     * ```ts
      * pbQuery<Post>().group((q) => q.equal('status', 'active').or().equal('status', 'inactive')); // (status~'active' || status~'inactive')
+     * ```
      */
     group(
         callback: (
@@ -706,14 +762,18 @@ export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6>
      * Combines the previous and the next conditions with an `and` logical operator.
      *
      * @example
+     * ```ts
      * pbQuery<User>().equal('name', 'Alice').and().equal('role', 'admin'); // name='Alice' && role='admin'
+     * ```
      */
     and(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
     /**
      * Combines the previous and the next conditions with an `or` logical operator.
      *
      * @example
+     * ```ts
      * pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
+     * ```
      */
     or(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
 }
@@ -725,14 +785,17 @@ export interface QueryBuilderEnd {
      * If a filter function is not provided (e.g. PocketBase's native `pb.filter`) as a parameter we return an object with the query string and values inside `filter`.
      *
      * @example
+     * ```ts
      * const query = pbQuery<User>().equal('name', 'Alice').build(pb.filter);
      *
      * // You can also filter it later
      * const { filter } = pbQuery<User>().equal('name', 'Alice').build();
      * console.log(filter); // { raw: 'name={:name1}', values: { name1: 'Alice' } }
      * console.log(pb.filter(filter.raw, filter.values)); // name='Alice'
+     * ```
      *
      * @example
+     * ```ts
      * const query = pbQuery<Post>()
      *     .fields([
      *         'title',
@@ -767,6 +830,9 @@ export interface QueryBuilderEnd {
      * //         },
      * //     },
      * // ]
+     * ```
+     *
+     * @since 0.3.0
      */
     build(): QueryResult<RawQueryObject>
     build(filter: FilterFunction): QueryResult<string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export type FilterFunction = (
 export type DatetimeMacro = (typeof DATETIME_MACROS)[number]
 
 export type RawQueryObject = { raw: string; values: Record<string, unknown> }
+export type QueryResult<T = string> = {
+    filter: T
+    fields: string
+    expand: string
+}
 
 export type GeoPoint = { lon: string; lat: string }
 
@@ -103,7 +108,7 @@ export type PathFields<
 > = D extends MaxDepth
     ? never
     : K extends string // This filters out symbol keys
-      ? KeyPathsFields<T, K, MaxDepth, D> // Now K is guaranteed to be string key
+      ? KeyPathsFields<T, K, MaxDepth, D> | '*' // Now K is guaranteed to be string key
       : never
 
 type KeyPathsFields<
@@ -112,11 +117,15 @@ type KeyPathsFields<
     MaxDepth extends number,
     D extends number,
 > = T[K] extends string
-    ? `${K}`
+    ?
+          | `${K}`
+          | `${K}:excerpt(${number},${boolean})`
+          | `${K}:excerpt(${number}, ${boolean})`
     : T[K] extends readonly object[]
       ?
             | `${K}`
             | `expand.${K}`
+            | `expand.${K}.*`
             | `expand.${K}.${PathFields<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
             | `${string}_via_${string}`
             | `expand.${string}_via_${string}`
@@ -133,6 +142,7 @@ type KeyPathsFields<
               ?
                     | `${K}`
                     | `expand.${K}`
+                    | `expand.${K}.*`
                     | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
                     | `${string}_via_${string}`
                     | `expand.${string}_via_${string}`
@@ -188,34 +198,101 @@ export type HandleModifier<V, Modifier extends string> = Modifier extends 'each'
 export interface QueryBuilderStart<T, MaxDepth extends number = 6>
     extends QueryBuilder<T, MaxDepth> {
     /**
-     * Matches records where `key` equals `value`.
+     * **_Starter_** - This can only be used once, at the start.
+     *
+     * Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+     *
+     * Modifiers:
+     * - `*` targets all keys from the specific depth level.
+     * - `:excerpt(maxLength, withEllipsis?)` returns a short plain text version of the field string value.
      *
      * @example
-     * pbQuery<Post>().select([
-     *     'title',
-     *     'author.email',
-     *     'author.name',
-     *     'author.profilePicture',
-     * ]); // 'title, author.email, author.name, author.profilePicture'
+     * const query = pbQuery<Post>()
+     *     .fields([
+     *         'title',
+     *         'content:excerpt(100,true)',
+     *         'author', // Be aware that `author` is not the same as `expand.author`.
+     *         'expand.author.name',
+     *         'expand.comments_via_post',
+     *     ])
+     *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
+     *     .build(pb.filter)
      *
-     * @example
-     * pbQuery<Post>().select([
-     *     'title',
-     *     { author: ['email', 'name', 'profilePicture'] },
-     * ]); // 'title, author.email, author.name, author.profilePicture'
+     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
+     * console.log(query.fields) // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+     * console.log(query.expand) // Output: 'author,comments_via_post'
+     *
+     * const records = await pb.collection('posts').getList(1, 20, query)
+     *
+     * console.log(records)
+     * // Output:
+     * // [
+     * //     {
+     * //         author: 'authorId',
+     * //         title: 'Football match this Saturday',
+     * //         content: 'Lorem ipsum dolor sit amet.',
+     * //         expand: {
+     * //             author: {
+     * //                 name: 'John',
+     * //             },
+     * //             comments_via_post: [
+     * //                 { ... },
+     * //             ],
+     * //         },
+     * //     },
+     * // ]
      */
     fields(keys: PathFields<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
 
     /**
-     * `expand()` is not needed if `select()`, we automatically include what to expand.
+     * **_Starter_** - This can only be used once, at the start.
+     *
+     * `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+     *
+     * Notes:
+     * - Supports up to 6-levels depth nested relations expansion.
+     * - The expanded relations will be appended to the record under the [`expand`](https://pocketbase.io/docs/working-with-relations/#expanding-relations) property (e.g. `"expand": { "relField1": { ... }, ... }`).
+     * - Only the relations to which the request user has permissions to view will be expanded.
+     *
+     * Read more about [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations) in the [official documentation](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
      *
      * @example
-     * pbQuery<Post>().expand(['author', 'comments_via_postId']); // 'author, comments_via_postId'
+     * const query = pbQuery<Post>()
+     *     .fields([
+     *         'title',
+     *         'content:excerpt(100,true)',
+     *         'author', // Be aware that `author` is not the same as `expand.author`.
+     *         'expand.author.name',
+     *         'expand.comments_via_post',
+     *     ])
+     *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
+     *     .build(pb.filter)
+     *
+     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
+     * console.log(query.fields) // Output: ''
+     * console.log(query.expand) // Output: 'author,comments_via_post'
+     *
+     * const records = await pb.collection('posts').getList(1, 20, query)
+     *
+     * console.log(records)
+     * // Output:
+     * // [
+     * //     {
+     * //         expand: {
+     * //             author: { ... },
+     * //             comments_via_post: [
+     * //                 { ... },
+     * //             ],
+     * //         },
+     * //         ...,
+     * //     },
+     * // ]
      */
     expand(keys: PathExpand<T, MaxDepth>[]): QueryBuilder<T, MaxDepth>
 }
 
-export interface QueryBuilder<T, MaxDepth extends number = 6> {
+export interface QueryBuilder<T, MaxDepth extends number = 6>
+    extends QueryBuilderEnd {
     /**
      * Matches records where `key` equals `value`.
      *
@@ -489,7 +566,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
      *
      * @example
      * // Full text search
-     * pbQuery<Post>().search(['title', 'content', 'tags', 'author.name', 'author.surname'], 'Football'); // (title~'Football' || content~'Football' || tags~'Football' || author.name~'Football' || author.surname~'Football')
+     * pbQuery<Post>().search(['title', 'content', 'tags', 'author.name'], 'Football'); // (title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')
      *
      * @example
      * // Contains
@@ -621,38 +698,10 @@ export interface QueryBuilder<T, MaxDepth extends number = 6> {
             q: QueryBuilder<T, MaxDepth>,
         ) => RestrictedQueryBuilder<T, MaxDepth>,
     ): RestrictedQueryBuilder<T, MaxDepth>
-
-    /**
-     * Returns the query string and values.
-     *
-     * @example
-     * // We recommend using Pocketbase's native `pb.filter()` function
-     * const query = pbQuery<User>().equal('name', 'Alice').build(pb.filter);
-     *
-     * // You can also filter it later
-     * const query = pbQuery<User>().equal('name', 'Alice').build();
-     * console.log(query.raw); // name={:name1}
-     * console.log(query.values); // { name: 'Alice' }
-     * console.log(pb.filter(query.raw, query.values)); // name='Alice'
-     */
-    build(): {
-        filter: { raw: string; values: Record<string, unknown> }
-        fields: string
-        expand: string
-    }
-    build(filter: FilterFunction): {
-        filter: string
-        fields: string
-        expand: string
-    }
-    build(filter?: FilterFunction): {
-        filter: { raw: string; values: Record<string, unknown> } | string
-        fields: string
-        expand: string
-    }
 }
 
-export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6> {
+export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6>
+    extends QueryBuilderEnd {
     /**
      * Combines the previous and the next conditions with an `and` logical operator.
      *
@@ -667,33 +716,59 @@ export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6> {
      * pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
      */
     or(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
+}
 
+export interface QueryBuilderEnd {
     /**
-     * Returns the query string and values.
+     * Returns an object with `filter`, `fields` and `expand`. Read more in the [official documentation](https://pocketbase.io/docs/api-records/#listsearch-records).
+     *
+     * If a filter function is not provided (e.g. PocketBase's native `pb.filter`) as a parameter we return an object with the query string and values inside `filter`.
      *
      * @example
-     * // We recommend using Pocketbase's native `pb.filter()` function
      * const query = pbQuery<User>().equal('name', 'Alice').build(pb.filter);
      *
      * // You can also filter it later
-     * const query = pbQuery<User>().equal('name', 'Alice').build();
-     * console.log(query.raw); // name={:name1}
-     * console.log(query.values); // { name: 'Alice' }
-     * console.log(pb.filter(query.raw, query.values)); // name='Alice'
+     * const { filter } = pbQuery<User>().equal('name', 'Alice').build();
+     * console.log(filter); // { raw: 'name={:name1}', values: { name1: 'Alice' } }
+     * console.log(pb.filter(filter.raw, filter.values)); // name='Alice'
+     *
+     * @example
+     * const query = pbQuery<Post>()
+     *     .fields([
+     *         'title',
+     *         'content:excerpt(100,true)',
+     *         'author',
+     *         'expand.author.name',
+     *         'expand.comments_via_post',
+     *     ]) // Optional
+     *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
+     *     .build(pb.filter)
+     *
+     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
+     * console.log(query.fields) // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+     * console.log(query.expand) // Output: 'author,comments_via_post'
+     *
+     * const records = await pb.collection('posts').getList(1, 20, query)
+     *
+     * console.log(records)
+     * // Output:
+     * // [
+     * //     {
+     * //         author: 'authorId',
+     * //         title: 'Football match this Saturday',
+     * //         content: 'Lorem ipsum dolor sit amet.',
+     * //         expand: {
+     * //             author: {
+     * //                 name: 'John',
+     * //             },
+     * //             comments_via_post: [
+     * //                 { ... },
+     * //             ],
+     * //         },
+     * //     },
+     * // ]
      */
-    build(): {
-        filter: RawQueryObject
-        fields: string
-        expand: string
-    }
-    build(filter: FilterFunction): {
-        filter: string
-        fields: string
-        expand: string
-    }
-    build(filter?: FilterFunction): {
-        filter: RawQueryObject | string
-        fields: string
-        expand: string
-    }
+    build(): QueryResult<RawQueryObject>
+    build(filter: FilterFunction): QueryResult<string>
+    build(filter?: FilterFunction): QueryResult<RawQueryObject | string>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,6 +251,16 @@ interface QueryBuilderStartReal<
      * // ]
      * ```
      *
+     * @example
+     * With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations), so you must specify it manually.
+     *
+     * ```ts
+     * const query = pbQuery<Post>()
+     *   .fields(['title', 'expand.*'])
+     *   .expand(['author', 'comments_via_post'])
+     *   .build(pb.filter);
+     * ```
+     *
      * @since 0.3.0
      */
     fields<P extends PathFields<T, MaxDepth>[]>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -219,11 +219,11 @@ interface QueryBuilderStartReal<
      * ```ts
      * const query = pbQuery<Post>()
      *     .fields([
-     *         'title',                       // Basic field
-     *         'content:excerpt(100,true)',   // Field with excerpt modifier
-     *         'author',                      // Relation ID field
-     *         'expand.author',               // Expanded relation field
-     *         'expand.comments_via_post',    // Back-relation expansion
+     *         'title',                     // Basic field
+     *         'content:excerpt(100,true)', // Field with excerpt modifier
+     *         'author',                    // Relation ID field
+     *         'expand.author',             // Expanded relation field
+     *         'expand.comments_via_post',  // Back-relation expansion
      *     ])
      *     .build(pb.filter);
      *
@@ -828,15 +828,15 @@ export interface QueryBuilderEnd {
      *         'expand.comments_via_post',
      *     ]) // Optional
      *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
-     *     .build(pb.filter)
+     *     .build(pb.filter);
      *
-     * console.log(query.filter) // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
-     * console.log(query.fields) // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
-     * console.log(query.expand) // Output: 'author,comments_via_post'
+     * console.log(query.filter); // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
+     * console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
+     * console.log(query.expand); // Output: 'author,comments_via_post'
      *
-     * const records = await pb.collection('posts').getList(1, 20, query)
+     * const records = await pb.collection('posts').getList(1, 20, query);
      *
-     * console.log(records)
+     * console.log(records);
      * // Output:
      * // [
      * //     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,13 +246,16 @@ export interface QueryBuilderStart<
      * ```
      *
      * @example
-     * With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations), so you must specify it manually.
+     * With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations), so it must be specified manually.
      *
      * ```ts
      * const query = pbQuery<Post>()
      *   .fields(['title', 'expand.*'])
      *   .expand(['author', 'comments_via_post'])
      *   .build(pb.filter);
+     *
+     * console.log(query.fields); // Output: 'title,expand.*'
+     * console.log(query.expand); // Output: 'author,comments_via_post'
      * ```
      *
      * @since 0.3.0
@@ -264,7 +267,7 @@ export interface QueryBuilderStart<
     /**
      * **_Starter_**, **_Once_** - This can only be used once, at the start.
      *
-     * `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+     * `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
      *
      * Notes:
      * - Supports up to 6-levels depth nested relations expansion.

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,7 +201,7 @@ export interface QueryBuilderStart<
     Once extends keyof QueryBuilderStart<T, MaxDepth> | '' = '',
 > extends QueryBuilder<T, MaxDepth> {
     /**
-     * **_Starter_** - This can only be used once, at the start.
+     * **_Starter_**, **_Once_** - This can only be used once, at the start.
      *
      * Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
      *
@@ -262,7 +262,7 @@ export interface QueryBuilderStart<
     ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'fields'>, Once | 'fields'>
 
     /**
-     * **_Starter_** - This can only be used once, at the start.
+     * **_Starter_**, **_Once_** - This can only be used once, at the start.
      *
      * `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,16 +195,10 @@ export type HandleModifier<V, Modifier extends string> = Modifier extends 'each'
         ? string
         : never
 
-export type QueryBuilderStart<
+export interface QueryBuilderStart<
     T,
     MaxDepth extends number = 6,
-    Ex extends keyof QueryBuilderStartReal<T, MaxDepth> | '' = '',
-> = Omit<QueryBuilderStartReal<T, MaxDepth, Ex>, Ex>
-
-interface QueryBuilderStartReal<
-    T,
-    MaxDepth extends number = 6,
-    Ex extends keyof QueryBuilderStartReal<T, MaxDepth> | '' = '',
+    Once extends keyof QueryBuilderStart<T, MaxDepth> | '' = '',
 > extends QueryBuilder<T, MaxDepth> {
     /**
      * **_Starter_** - This can only be used once, at the start.
@@ -265,7 +259,7 @@ interface QueryBuilderStartReal<
      */
     fields<P extends PathFields<T, MaxDepth>[]>(
         keys: P,
-    ): QueryBuilderStart<T, MaxDepth, Ex | 'fields'>
+    ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'fields'>, Once | 'fields'>
 
     /**
      * **_Starter_** - This can only be used once, at the start.
@@ -312,7 +306,7 @@ interface QueryBuilderStartReal<
      */
     expand<P extends PathExpand<T, MaxDepth>[]>(
         keys: P,
-    ): QueryBuilderStart<T, MaxDepth, Ex | 'expand'>
+    ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'expand'>, Once | 'expand'>
 }
 
 export interface QueryBuilder<T, MaxDepth extends number = 6>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,54 @@ function isMacro(value: unknown): value is string {
 
     return value.length > 1 && value.startsWith('@')
 }
+
+export function generateFields(keys: string[]) {
+    const uniqueKeys = [...new Set(keys)]
+
+    return uniqueKeys.join(',')
+}
+
+export function prepareFieldsForExpand(keys: string[]) {
+    const uniqueKeys = [...new Set(keys)]
+
+    const preparedKeys = uniqueKeys.map((key) => {
+        const words = key.split('expand.')
+        if (words.length > 1) {
+            return words
+                .map((word) => {
+                    const dotIndex = word.lastIndexOf('.')
+                    return word.slice(0, dotIndex < 0 ? word.length : dotIndex)
+                })
+                .filter(Boolean)
+                .join('.')
+        }
+
+        return ''
+    })
+
+    return [...new Set(preparedKeys)]
+}
+
+export function generateExpand(keys: string[]) {
+    const uniqueKeys = [...new Set(keys)]
+
+    return uniqueKeys
+        .reduce((acc, word, wordIndex, arr) => {
+            const canBeIgnored = arr.some((x, xIndex) => {
+                if (wordIndex === xIndex) {
+                    return false
+                }
+
+                if (x?.startsWith(word)) {
+                    return true
+                }
+            })
+
+            if (!canBeIgnored) {
+                acc.push(word)
+            }
+
+            return acc
+        }, [] as string[])
+        .join(',')
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,7 +70,7 @@ export function prepareFieldsForExpand(keys: string[]) {
         if (words.length > 1) {
             return words
                 .map((word) => {
-                    const dotIndex = word.lastIndexOf('.')
+                    const dotIndex = word.indexOf('.')
                     return word.slice(0, dotIndex < 0 ? word.length : dotIndex)
                 })
                 .filter(Boolean)

--- a/tests/query.test-d.ts
+++ b/tests/query.test-d.ts
@@ -1,6 +1,12 @@
 import { assertType, expectTypeOf, test } from 'vitest'
 import { pbQuery } from '../src/query'
-import type { Path, RawQueryObject } from '../src/types'
+import type {
+    GeoPoint,
+    Path,
+    PathExpand,
+    PathFields,
+    RawQueryObject,
+} from '../src/types'
 import { filter } from '../src/utils'
 
 interface User {
@@ -9,6 +15,7 @@ interface User {
     age: number
     city: string
     permissions: string[]
+    location: GeoPoint
 }
 
 interface Category {
@@ -59,24 +66,18 @@ test('all possible keys', () => {
     equal('isVisible', true).build()
     equal('user', 'hola').build()
     equal('user.age', 18).build()
+
+    expectTypeOf<'user'>().toMatchTypeOf<PathExpand<Post, 6>>()
+    expectTypeOf<'user.location'>().not.toMatchTypeOf<PathExpand<Post, 6>>()
+    expectTypeOf<'created'>().not.toMatchTypeOf<PathExpand<Post, 6>>()
+
+    expectTypeOf<'user'>().toMatchTypeOf<PathFields<Post, 6>>()
+    expectTypeOf<'expand.user'>().toMatchTypeOf<PathFields<Post, 6>>()
+    expectTypeOf<'expand.user.name'>().toMatchTypeOf<PathFields<Post, 6>>()
+    expectTypeOf<'expand.location'>().not.toMatchTypeOf<PathFields<User, 6>>()
+    expectTypeOf<'location'>().toMatchTypeOf<PathFields<User, 6>>()
+    expectTypeOf<'location.lon'>().toMatchTypeOf<PathFields<User, 6>>()
+
     expectTypeOf<'anything_via_user'>().not.toMatchTypeOf<Path<Post, 6>>()
     equal('anything_via_user.anything', new Date()).build()
 })
-
-// type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T
-//     ? 1
-//     : 2) extends <G>() => G extends U ? 1 : 2
-//     ? Y
-//     : N
-
-// type Actual = {
-//     point: GeoPoint
-//     hola: string
-// }
-
-// type Expected = {
-//     point: GeoPoint
-// }
-
-// type Equal = IfEquals<Actual, Expected>
-// type Equal2 = IfEquals<Expected, Actual>

--- a/tests/query.test-d.ts
+++ b/tests/query.test-d.ts
@@ -71,9 +71,14 @@ test('all possible keys', () => {
     expectTypeOf<'user.location'>().not.toMatchTypeOf<PathExpand<Post, 6>>()
     expectTypeOf<'created'>().not.toMatchTypeOf<PathExpand<Post, 6>>()
 
+    expectTypeOf<'*'>().toMatchTypeOf<PathFields<Post, 6>>()
     expectTypeOf<'user'>().toMatchTypeOf<PathFields<Post, 6>>()
     expectTypeOf<'expand.user'>().toMatchTypeOf<PathFields<Post, 6>>()
+    expectTypeOf<'expand.user.*'>().toMatchTypeOf<PathFields<Post, 6>>()
     expectTypeOf<'expand.user.name'>().toMatchTypeOf<PathFields<Post, 6>>()
+    expectTypeOf<'content:excerpt(100,true)'>().toMatchTypeOf<
+        PathFields<Post, 6>
+    >()
     expectTypeOf<'expand.location'>().not.toMatchTypeOf<PathFields<User, 6>>()
     expectTypeOf<'location'>().toMatchTypeOf<PathFields<User, 6>>()
     expectTypeOf<'location.lon'>().toMatchTypeOf<PathFields<User, 6>>()

--- a/tests/query.test-d.ts
+++ b/tests/query.test-d.ts
@@ -33,8 +33,8 @@ interface Post {
 test('build function types', () => {
     const { build } = pbQuery<Post>()
 
-    assertType<string>(build(filter))
-    assertType<RawQueryObject>(build())
+    assertType<string>(build(filter).filter)
+    assertType<RawQueryObject>(build().filter)
 })
 
 test('all possible keys', () => {
@@ -62,3 +62,21 @@ test('all possible keys', () => {
     expectTypeOf<'anything_via_user'>().not.toMatchTypeOf<Path<Post, 6>>()
     equal('anything_via_user.anything', new Date()).build()
 })
+
+// type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T
+//     ? 1
+//     : 2) extends <G>() => G extends U ? 1 : 2
+//     ? Y
+//     : N
+
+// type Actual = {
+//     point: GeoPoint
+//     hola: string
+// }
+
+// type Expected = {
+//     point: GeoPoint
+// }
+
+// type Equal = IfEquals<Actual, Expected>
+// type Equal2 = IfEquals<Expected, Actual>

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -249,6 +249,10 @@ test('fields', () => {
     const query2 = pbQuery<Post>().build(filter)
     expect(query2.fields).toBe('')
     expect(query2.expand).toBe('')
+
+    const query3 = pbQuery<Post>().fields('*').build(filter)
+    expect(query3.fields).toBe('*')
+    expect(query3.expand).toBe('')
 })
 
 test('expand', () => {
@@ -277,4 +281,7 @@ test('expand', () => {
     expect(query2.expand).toBe(
         ['author.a_via_b.record.b_via_c', 'related'].join(','),
     )
+
+    const query3 = pbQuery<Post>().expand('author').build(filter)
+    expect(query3.expand).toBe(['author'].join(','))
 })

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -210,8 +210,10 @@ test('date macros', () => {
 test('select', () => {
     const query1 = pbQuery<Post>()
         .fields([
+            '*',
             'title',
             'tags',
+            'content:excerpt(100,true)',
             'author',
             'expand.author.location.lon',
             'expand.author.location.lat',
@@ -220,13 +222,15 @@ test('select', () => {
             'expand.author.expand.a_via_b',
             'expand.author.expand.a_via_b.expand.record.expand.b_via_c',
             'related',
-            'expand.related.updated',
+            'expand.related.*',
         ])
         .build(filter)
     expect(query1.fields).toBe(
         [
+            '*',
             'title',
             'tags',
+            'content:excerpt(100,true)',
             'author',
             'expand.author.location.lon',
             'expand.author.location.lat',
@@ -235,7 +239,7 @@ test('select', () => {
             'expand.author.expand.a_via_b',
             'expand.author.expand.a_via_b.expand.record.expand.b_via_c',
             'related',
-            'expand.related.updated',
+            'expand.related.*',
         ].join(','),
     )
     expect(query1.expand).toBe(

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -207,7 +207,7 @@ test('date macros', () => {
     expect(query3.filter).toBe("created>'@test'")
 })
 
-test('select', () => {
+test('fields', () => {
     const query1 = pbQuery<Post>()
         .fields([
             '*',
@@ -259,8 +259,22 @@ test('expand', () => {
             'author.a_via_b.record.b_via_c',
             'related',
         ])
+        .fields(['related'])
         .build(filter)
     expect(query1.expand).toBe(
+        ['author.a_via_b.record.b_via_c', 'related'].join(','),
+    )
+
+    const query2 = pbQuery<Post>()
+        .fields(['related'])
+        .expand([
+            'author',
+            'author.a_via_b',
+            'author.a_via_b.record.b_via_c',
+            'related',
+        ])
+        .build(filter)
+    expect(query2.expand).toBe(
         ['author.a_via_b.record.b_via_c', 'related'].join(','),
     )
 })

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,6 +1,7 @@
 import PocketBase from 'pocketbase'
 import { expect, test } from 'vitest'
 import { pbQuery } from '../src/query'
+import type { GeoPoint } from '../src/types'
 import { filter } from '../src/utils'
 
 interface User {
@@ -9,6 +10,7 @@ interface User {
     age: number
     city: string
     permissions: string[]
+    location: GeoPoint
     created: Date
     updated: Date
 }
@@ -211,6 +213,8 @@ test('select', () => {
             'title',
             'tags',
             'author',
+            'expand.author.location.lon',
+            'expand.author.location.lat',
             'expand.author.city',
             'expand.author.age',
             'expand.author.expand.a_via_b',
@@ -220,9 +224,23 @@ test('select', () => {
         ])
         .build(filter)
     expect(query1.fields).toBe(
-        'title,tags,author,expand.author.city,expand.author.age,expand.author.expand.a_via_b,expand.author.expand.a_via_b.expand.record.expand.b_via_c,related,expand.related.updated',
+        [
+            'title',
+            'tags',
+            'author',
+            'expand.author.location.lon',
+            'expand.author.location.lat',
+            'expand.author.city',
+            'expand.author.age',
+            'expand.author.expand.a_via_b',
+            'expand.author.expand.a_via_b.expand.record.expand.b_via_c',
+            'related',
+            'expand.related.updated',
+        ].join(','),
     )
-    expect(query1.expand).toBe('author.a_via_b.record.b_via_c,related')
+    expect(query1.expand).toBe(
+        ['author.a_via_b.record.b_via_c', 'related'].join(','),
+    )
 
     const query2 = pbQuery<Post>().build(filter)
     expect(query2.fields).toBe('')
@@ -238,5 +256,7 @@ test('expand', () => {
             'related',
         ])
         .build(filter)
-    expect(query1.expand).toBe('author.a_via_b.record.b_via_c,related')
+    expect(query1.expand).toBe(
+        ['author.a_via_b.record.b_via_c', 'related'].join(','),
+    )
 })

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -72,13 +72,13 @@ test('filter discrepancy', () => {
         .custom(pb.filter('content~{:content}', { content: 'test' }))
         .build(pb.filter)
 
-    expect(query1).toBe(query2)
+    expect(query1.filter).toBe(query2.filter)
 })
 
 test('post query', () => {
     const postQuery = pbQuery<Post>
 
-    expect(postQuery().equal('author.name', 'John').build(filter)).toBe(
+    expect(postQuery().equal('author.name', 'John').build(filter).filter).toBe(
         "author.name='John'",
     )
     expect(
@@ -86,7 +86,7 @@ test('post query', () => {
             .equal('author.name', 'John')
             .and()
             .equal('author.age', 20)
-            .build(filter),
+            .build(filter).filter,
     ).toBe("author.name='John' && author.age=20")
 })
 
@@ -99,7 +99,9 @@ test('multiple queries', () => {
         .equal('city', 'New York')
         .build(filter)
 
-    expect(query).toBe("name='John' && (age!=20 || age!=30) && city='New York'")
+    expect(query.filter).toBe(
+        "name='John' && (age!=20 || age!=30) && city='New York'",
+    )
 
     const query1 = pbQuery<Post>()
         .equal('author.name', 'John')
@@ -119,7 +121,7 @@ test('multiple queries', () => {
         .custom(filter('content~{:content}', { content: 'test' }))
         .build()
 
-    expect(filter(query1.raw, query1.values)).toBe(
+    expect(filter(query1.filter.raw, query1.filter.values)).toBe(
         "author.name='John' && (title?!~'foo' || title?~'bar') && (author.age=20 || author.age=30 || author.age=40) && (created>='2021-01-01 00:00:00.000Z' && created<='2021-12-31 00:00:00.000Z') && (author.age<20 || author.age>30) && (author.city='New York' || author.city='Los Angeles') && (author.city!='Chicago' && author.city!='Miami') && content~'test'",
     )
 
@@ -131,7 +133,7 @@ test('multiple queries', () => {
         .group((q) => q.equal('name', 'Alice').or().equal('name', 'Bob'))
         .build(filter)
 
-    expect(groupTest).toBe(
+    expect(groupTest.filter).toBe(
         "name='Alice' || name='Bob' && (name='Alice' || name='Bob')",
     )
 })
@@ -154,7 +156,7 @@ test('nested groups', () => {
         )
         .build(filter)
 
-    expect(groupTest).toBe(
+    expect(groupTest.filter).toBe(
         "name='Alice' || name='Bob' && (name='Alice' || name='Bob') && (name!='' && (name='Alice' || name='Bob'))",
     )
 })
@@ -164,7 +166,7 @@ test('back-relations', () => {
         .equal('anything_via_author.anything', new Date('2021-12-31'))
         .build(filter)
 
-    expect(groupTest).toBe(
+    expect(groupTest.filter).toBe(
         "anything_via_author.anything='2021-12-31 00:00:00.000Z'",
     )
 })
@@ -176,29 +178,65 @@ test('cloned query', () => {
     const searchQuery1 = querySportsPosts()
         .search(['title', 'content', 'tags', 'author'], 'basketba')
         .build(pb.filter)
-    expect(searchQuery1).toBe(
+    expect(searchQuery1.filter).toBe(
         "tags?~'sports' && (title~'basketba' || content~'basketba' || tags~'basketba' || author~'basketba')",
     )
 
     const searchQuery2 = querySportsPosts()
         .search(['title', 'content', 'tags', 'author'], 'footba')
         .build(pb.filter)
-    expect(searchQuery2).toBe(
+    expect(searchQuery2.filter).toBe(
         "tags?~'sports' && (title~'footba' || content~'footba' || tags~'footba' || author~'footba')",
     )
 })
 
 test('date macros', () => {
     const query1 = pbQuery<Post>().greaterThan('created', '@now').build(filter)
-    expect(query1).toBe('created>@now')
+    expect(query1.filter).toBe('created>@now')
 
     const query2 = pbQuery<Post>()
         .between('created', '@now', '@yesterday')
         .build(filter)
-    expect(query2).toBe('(created>=@now && created<=@yesterday)')
+    expect(query2.filter).toBe('(created>=@now && created<=@yesterday)')
 
     const query3 = pbQuery<Post>()
         .greaterThan('created', '@test' as '@now')
         .build(filter)
-    expect(query3).toBe("created>'@test'")
+    expect(query3.filter).toBe("created>'@test'")
+})
+
+test('select', () => {
+    const query1 = pbQuery<Post>()
+        .fields([
+            'title',
+            'tags',
+            'author',
+            'expand.author.city',
+            'expand.author.age',
+            'expand.author.expand.a_via_b',
+            'expand.author.expand.a_via_b.expand.record.expand.b_via_c',
+            'related',
+            'expand.related.updated',
+        ])
+        .build(filter)
+    expect(query1.fields).toBe(
+        'title,tags,author,expand.author.city,expand.author.age,expand.author.expand.a_via_b,expand.author.expand.a_via_b.expand.record.expand.b_via_c,related,expand.related.updated',
+    )
+    expect(query1.expand).toBe('author.a_via_b.record.b_via_c,related')
+
+    const query2 = pbQuery<Post>().build(filter)
+    expect(query2.fields).toBe('')
+    expect(query2.expand).toBe('')
+})
+
+test('expand', () => {
+    const query1 = pbQuery<Post>()
+        .expand([
+            'author',
+            'author.a_via_b',
+            'author.a_via_b.record.b_via_c',
+            'related',
+        ])
+        .build(filter)
+    expect(query1.expand).toBe('author.a_via_b.record.b_via_c,related')
 })


### PR DESCRIPTION
## Fields

**_Starter_**, **_Once_** - This can only be used once, at the start.

Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).

Modifiers:
- `*` – Targets all keys from the specific depth level.
- `:excerpt(maxLength, withEllipsis?)` – Returns a short plain text version of the field string value.

```ts
const query = pbQuery<Post>()
  .fields([
    'title',                       // Basic field
    'content:excerpt(100,true)',   // Field with excerpt modifier
    'author',                      // Relation ID field
    'expand.author',               // Expanded relation field
    'expand.comments_via_post',    // Back-relation expansion
  ])
  .build(pb.filter);

console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
console.log(query.expand); // Output: 'author,comments_via_post'

const records = await pb.collection('posts').getList(1, 20, query);

console.log(records);
// Output:
// [
//   {
//     author: 'authorId',
//     title: 'Football match this Saturday',
//     content: 'Lorem ipsum dolor sit amet.',
//     expand: {
//       author: {
//         name: 'John',
//       },
//       comments_via_post: [
//         { ... },
//       ],
//     },
//   },
// ]
```

> [!WARNING]
> With the key `expand.*` we can't automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations), so you must specify it manually.
> ```ts
> const query = pbQuery<Post>()
>   .fields(['title', 'expand.*'])
>   .expand(['author', 'comments_via_post'])
>   .build(pb.filter);
>
> console.log(query.fields); // Output: 'title,expand.*'
> console.log(query.expand); // Output: 'author,comments_via_post'
> ```

## Expand

**_Starter_**, **_Once_** - This can only be used once, at the start.

`expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.

Notes:
- Supports up to 6-levels depth nested relations expansion.
- The expanded relations will be appended to the record under the [`expand`](https://pocketbase.io/docs/working-with-relations/#expanding-relations) property (e.g. `"expand": { "relField1": { ... }, ... }`).
- Only the relations to which the request user has permissions to view will be expanded.

Read more about [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations) in the [official documentation](https://pocketbase.io/docs/working-with-relations/#expanding-relations).

```ts
const query = pbQuery<Post>()
  .expand([
    'author',
    'comments_via_post',
  ])
  .build(pb.filter);

console.log(query.fields); // Output: ''
console.log(query.expand); // Output: 'author,comments_via_post'

const records = await pb.collection('posts').getList(1, 20, query);

console.log(records);
// Output:
// [
//   {
//     expand: {
//       author: { ... },
//         comments_via_post: [
//           { ... },
//         ],
//       },
//     ...,
//   },
// ]
```