### PR TITLE
Add helper for building `sort`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ const query = pbQuery<Post>()
       .and()
       .greaterThan('priority', 5)
   )
+  .sort(['title', '-created'])
   .build(pb.filter);
 
 console.log(query.expand);
@@ -87,6 +88,9 @@ console.log(query.filter);
 // Output: "(title~'footba' || content~'footba' || tags~'footba' || author~'footba')
 // && (created>='2023-01-01 00:00:00.000Z' && created<='2023-12-31 00:00:00.000Z')
 // || (tags?~'sports' && priority>5)"
+
+console.log(query.sort);
+// Output: 'title,-created'
 
 // Use your query
 const records = await pb.collection("posts").getList(1, 20, query);
@@ -107,7 +111,7 @@ const records = await pb.collection("posts").getList(1, 20, query);
 routerAdd("GET", "/example", (e) => {
   const { pbQuery } = require('@sergio9929/pb-query');
 
-  const { filter } = pbQuery()
+  const { filter, sort } = pbQuery()
     .search(['title', 'content', 'tags.title', 'author'], 'footba')
     .and()
     .between('created', new Date('2023-01-01'), new Date('2024-12-31'))
@@ -117,12 +121,13 @@ routerAdd("GET", "/example", (e) => {
         .and()
         .greaterThan('priority', 5)
     )
+    .sort(['title', '-created'])
     .build();
 
   const records = $app.findRecordsByFilter(
     'posts',
     filter.raw,
-    '',
+    sort,
     20,
     0,
     filter.values,
@@ -141,6 +146,7 @@ routerAdd("GET", "/example", (e) => {
 - 🛠️ [Multiple Operators](#multiple-operators)
 - ⚡ [Helper Operators](#helper-operators)
 - 🔍 [Fields and Expand](#fields-and-expand)
+- ⬇️ [Sorting](#sorting)
 - 💡 [Tips and Tricks](#tips-and-tricks)
 - 🚨 [Troubleshooting](#troubleshooting)
 - 🙏 [Credits](#credits)
@@ -183,6 +189,7 @@ console.log(query);
 // {
 //   fields: '',
 //   expand: '',
+//   sort: '',
 //   filter: {
 //     raw: 'content~{:content1}',
 //     values: { content1: 'Top Secret%' }
@@ -717,6 +724,32 @@ console.log(records);
 //     ...,
 //   },
 // ]
+```
+
+## Sorting
+
+#### `.sort(fields)`
+
+_Since v0.3.0_
+
+**_Once_** - This can only be used once.
+
+Sorts the results by the specified keys.
+
+Prefixes:
+- `-` – Descending order.
+- `+` – **DEFAULT**. Ascending order.
+
+Macros:
+- `@random` – Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
+- `@rowid` – **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
+
+```ts
+const query = pbQuery<Post>()
+   .sort(['title', '-created'])
+   .build(pb.filter);
+
+console.log(query.sort) // Output: 'title,-created'
 ```
 
 ## Tips and tricks

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ pbQuery<Post>()
 
 ### Macros
 
-Native [PocketBase datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) are supported: `@now`, `@yesterday`, `@tomorrow`, `@todayStart`, `@todayEnd`, `@monthStart`, `@monthEnd`, `@yearStart`, `@yearEnd`
+Native [PocketBase datetime macros](https://pocketbase.io/docs/api-rules-and-filters/#-macros) are supported:
 - `@now` – Current datetime.
 - `@yesterday` – 24 hours before `@now`.
 - `@tomorrow` – 24 hours after`@now`.

--- a/README.md
+++ b/README.md
@@ -622,13 +622,15 @@ pbQuery<User>().isNotNull('name'); // name!=''
 
 ### Field Selection
 
-#### `.fields(fields)`
+#### `.fields(keys)`
 
 _Since v0.3.0_
 
 **_Starter_**, **_Once_** - This can only be used once, at the start.
 
-Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+Accepts a single key or an array of keys.
+
+Selects which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
 
 Modifiers:
 - `*` – Targets all keys from the specific depth level.
@@ -683,13 +685,15 @@ console.log(records);
 
 ### Expand Related Records
 
-#### `.expand(fields)`
+#### `.expand(keys)`
 
 _Since v0.3.0_
 
 **_Starter_**, **_Once_** - This can only be used once, at the start.
 
-`expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
+Accepts a single key or an array of keys.
+
+Expands information from related collections. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
 
 Notes:
 - Supports up to 6-levels depth nested relations expansion.
@@ -728,11 +732,13 @@ console.log(records);
 
 ## Sorting
 
-#### `.sort(fields)`
+#### `.sort(keys)`
 
 _Since v0.3.0_
 
 **_Once_** - This can only be used once.
+
+Accepts a single key or an array of keys.
 
 Sorts the results by the specified keys.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add @sergio9929/pb-query
 
 ## Version Compatibility
 
-You are reading the documentation for versions equal or higher to `pb-query@0.3.0`.
+You are reading the documentation for versions equal or higher to `0.3.0`.
 
 | PocketBase | pb-query | documentation |
 | - | - | - |

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,15 @@
+export { OPERATORS } from './src/constants'
 export { pbQuery } from './src/query'
 export type {
+    DatetimeMacro,
     FilterFunction,
+    GeoPoint,
+    Path,
+    PathExpand,
+    PathFields,
+    PathSort,
     QueryBuilder,
+    RawQueryObject,
     RestrictedQueryBuilder,
 } from './src/types'
-export { OPERATORS } from './src/constants'
 export { filter } from './src/utils'

--- a/src/query.ts
+++ b/src/query.ts
@@ -12,6 +12,7 @@ import type {
 import {
     generateExpand,
     generateFields,
+    generateSort,
     isDateMacro,
     prepareFieldsForExpand,
 } from './utils'
@@ -23,6 +24,7 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
     let query = ''
     let fields = ''
     let expand = ''
+    let sort = ''
 
     const keyCounter = new Map<Path<T, MaxDepth>, number>()
     const valueMap = new Map<string, unknown>()
@@ -89,12 +91,14 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
                 expand,
                 fields,
                 filter: filter(query, Object.fromEntries(valueMap)),
+                sort,
             }
         }
         return {
             expand,
             fields,
             filter: { raw: query, values: Object.fromEntries(valueMap) },
+            sort,
         }
     }
 
@@ -162,6 +166,16 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
             query += ')'
             return restrictedQueryBuilder
         },
+        sort(keys) {
+            if (sort) {
+                console.warn('Overriding previous sort:', sort)
+            }
+
+            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
+            sort = generateSort(normalizedKeys)
+
+            return queryBuilder
+        },
         build,
     }
 
@@ -198,6 +212,16 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
         or() {
             query += ' || '
             return queryBuilder
+        },
+        sort(keys) {
+            if (sort) {
+                console.warn('Overriding previous sort:', sort)
+            }
+
+            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
+            sort = generateSort(normalizedKeys)
+
+            return restrictedQueryBuilder
         },
         build,
     }

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,7 @@
 import { OPERATORS } from './constants'
 import type {
     FilterFunction,
+    OperatorMethod,
     Path,
     PathValue,
     QueryBuilder,
@@ -66,12 +67,9 @@ export function pbQuery<
         values: PathValue<T, P, MaxDepth>,
     ) => RestrictedQueryBuilder<T, MaxDepth>
 
-    const builderFunctions = {} as Record<
-        keyof typeof OPERATORS,
-        BuilderFunction
-    >
+    const builderFunctions = {} as Record<OperatorMethod, BuilderFunction>
     for (const [name, operator] of Object.entries(OPERATORS)) {
-        const key = name as keyof typeof OPERATORS
+        const key = name as OperatorMethod
         builderFunctions[key] = <P extends Path<T, MaxDepth>>(
             key: P,
             value: PathValue<T, P, MaxDepth>,

--- a/src/query.ts
+++ b/src/query.ts
@@ -102,6 +102,15 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
         }
     }
 
+    function applySort(keys: string | string[]) {
+        if (sort) {
+            console.warn('Overriding previous sort:', sort)
+        }
+
+        const normalizedKeys = Array.isArray(keys) ? keys : [keys]
+        sort = generateSort(normalizedKeys)
+    }
+
     const queryBuilder: QueryBuilder<T, MaxDepth> = {
         ...builderFunctions,
         search(keys, value) {
@@ -167,12 +176,7 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
             return restrictedQueryBuilder
         },
         sort(keys) {
-            if (sort) {
-                console.warn('Overriding previous sort:', sort)
-            }
-
-            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
-            sort = generateSort(normalizedKeys)
+            applySort(keys)
 
             return queryBuilder
         },
@@ -214,12 +218,7 @@ export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
             return queryBuilder
         },
         sort(keys) {
-            if (sort) {
-                console.warn('Overriding previous sort:', sort)
-            }
-
-            const normalizedKeys = Array.isArray(keys) ? keys : [keys]
-            sort = generateSort(normalizedKeys)
+            applySort(keys)
 
             return restrictedQueryBuilder
         },

--- a/src/query.ts
+++ b/src/query.ts
@@ -17,10 +17,10 @@ import {
     prepareFieldsForExpand,
 } from './utils'
 
-export function pbQuery<T, MaxDepth extends number = 6>(): QueryBuilderStart<
-    T,
-    MaxDepth
-> {
+export function pbQuery<
+    T = Record<string, unknown>,
+    MaxDepth extends number = 6,
+>(): QueryBuilderStart<T, MaxDepth> {
     let query = ''
     let fields = ''
     let expand = ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,34 +33,58 @@ export type Path<
     D extends number = 0,
 > = D extends MaxDepth
     ? never
-    : K extends string // This filters out symbol keys
-      ? KeyPaths<T, K, MaxDepth, D> // Now K is guaranteed to be string key
-      : never
-
-type KeyPaths<
-    T,
-    K extends string & keyof T,
-    MaxDepth extends number,
-    D extends number,
-> = T[K] extends string
-    ? `${K}` | `${K}:lower`
-    : T[K] extends readonly object[]
-      ?
+    : K extends string // This filters out symbol keys, now K is guaranteed to be string key
+      ? PathHelper<
+            T,
+            K,
+            // Text
+            `${K}` | `${K}:lower`,
+            // Date
+            `${K}`,
+            // GeoPoint
+            `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+            // Multiple
+            `${K}` | `${K}:each` | `${K}:length`,
+            // Relation
+            | `${K}`
+            | `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+            | `${string}_via_${string}.${string}`,
+            // Multiple Relation
             | `${K}`
             | `${K}:each`
             | `${K}:length`
-            | `${K}.${Path<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
-            | `${string}_via_${string}.${string}`
+            | `${K}.${Path<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+            | `${string}_via_${string}.${string}`,
+            // Other
+            `${K}`
+        >
+      : never
+
+type Elem<T> = T extends readonly (infer U)[] ? U : never
+
+type PathHelper<
+    T,
+    K extends keyof T & string,
+    TextField,
+    DateField,
+    GeoPointField,
+    MultipleField,
+    RelationField,
+    MultipleRelationField,
+    Other,
+> = T[K] extends string
+    ? TextField
+    : T[K] extends readonly object[]
+      ? MultipleRelationField
       : T[K] extends readonly unknown[]
-        ? `${K}` | `${K}:each` | `${K}:length`
+        ? MultipleField
         : T[K] extends Date
-          ? `${K}`
-          : T[K] extends object
-            ?
-                  | `${K}`
-                  | `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-                  | `${string}_via_${string}.${string}`
-            : `${K}`
+          ? DateField
+          : Exact<T[K], GeoPoint, 1, 2> extends 1
+            ? GeoPointField
+            : T[K] extends object
+              ? RelationField
+              : Other
 
 export type PathExpand<
     T,
@@ -69,36 +93,32 @@ export type PathExpand<
     D extends number = 0,
 > = D extends MaxDepth
     ? never
-    : K extends string // This filters out symbol keys
-      ? KeyPathsExpand<T, K, MaxDepth, D> // Now K is guaranteed to be string key
-      : never
-
-type KeyPathsExpand<
-    T,
-    K extends string & keyof T,
-    MaxDepth extends number,
-    D extends number,
-> = T[K] extends string
-    ? never
-    : T[K] extends readonly object[]
-      ?
+    : K extends string // This filters out symbol keys, now K is guaranteed to be string key
+      ? PathHelper<
+            T,
+            K,
+            // Text
+            never,
+            // Date
+            never,
+            // GeoPoint
+            never,
+            // Multiple
+            never,
+            // Relation
             | `${K}`
-            | `${K}.${PathExpand<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
+            | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
             | `${string}_via_${string}`
-            | `${string}_via_${string}.${string}`
-      : T[K] extends readonly unknown[]
-        ? never
-        : T[K] extends Date
-          ? never
-          : Exact<T[K], GeoPoint, 1, 2> extends 1
-            ? never
-            : T[K] extends object
-              ?
-                    | `${K}`
-                    | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-                    | `${string}_via_${string}`
-                    | `${string}_via_${string}.${string}`
-              : never
+            | `${string}_via_${string}.${string}`,
+            // Multiple Relation
+            | `${K}`
+            | `${K}.${PathExpand<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+            | `${string}_via_${string}`
+            | `${string}_via_${string}.${string}`,
+            // Other
+            never
+        >
+      : never
 
 export type PathFields<
     T,
@@ -107,47 +127,43 @@ export type PathFields<
     D extends number = 0,
 > = D extends MaxDepth
     ? never
-    : K extends string // This filters out symbol keys
-      ? KeyPathsFields<T, K, MaxDepth, D> | '*' // Now K is guaranteed to be string key
-      : never
-
-type KeyPathsFields<
-    T,
-    K extends string & keyof T,
-    MaxDepth extends number,
-    D extends number,
-> = T[K] extends string
-    ?
-          | `${K}`
-          | `${K}:excerpt(${number},${boolean})`
-          | `${K}:excerpt(${number}, ${boolean})`
-    : T[K] extends readonly object[]
+    : K extends string // This filters out symbol keys, now K is guaranteed to be string key
       ?
-            | `${K}`
-            | `expand.${K}`
-            | `expand.${K}.*`
-            | `expand.${K}.${PathFields<T[K][number], MaxDepth, keyof T[K][number], DepthCounter[D]>}`
-            | `${string}_via_${string}`
-            | `expand.${string}_via_${string}`
-            | `expand.${string}_via_${string}.${string}`
-      : T[K] extends readonly unknown[]
-        ? `${K}`
-        : T[K] extends Date
-          ? `${K}`
-          : Exact<T[K], GeoPoint, 1, 2> extends 1
-            ?
+            | PathHelper<
+                  T,
+                  K,
+                  // Text
                   | `${K}`
-                  | `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-            : T[K] extends object
-              ?
-                    | `${K}`
-                    | `expand.${K}`
-                    | `expand.${K}.*`
-                    | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
-                    | `${string}_via_${string}`
-                    | `expand.${string}_via_${string}`
-                    | `expand.${string}_via_${string}.${string}`
-              : `${K}`
+                  | `${K}:excerpt(${number},${boolean})`
+                  | `${K}:excerpt(${number}, ${boolean})`,
+                  // Date
+                  `${K}`,
+                  // GeoPoint
+                  | `${K}`
+                  | `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+                  // Multiple
+                  `${K}`,
+                  // Relation
+                  | `${K}`
+                  | `expand.${K}`
+                  | `expand.${K}.*`
+                  | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                  | `${string}_via_${string}`
+                  | `expand.${string}_via_${string}`
+                  | `expand.${string}_via_${string}.${string}`,
+                  // Multiple Relation
+                  | `${K}`
+                  | `expand.${K}`
+                  | `expand.${K}.*`
+                  | `expand.${K}.${PathFields<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+                  | `${string}_via_${string}`
+                  | `expand.${string}_via_${string}`
+                  | `expand.${string}_via_${string}.${string}`,
+                  // Other
+                  `${K}`
+              >
+            | '*'
+      : never
 
 type PathValueHelper<
     T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,7 +379,13 @@ export interface QueryBuilder<
     T,
     MaxDepth extends number = 6,
     Once extends keyof QueryBuilder<T, MaxDepth> | '' = '',
-> extends QueryBuilderEnd {
+> extends QueryBuilderEnd,
+        SortMethod<
+            T,
+            MaxDepth,
+            QueryBuilder<T, MaxDepth, Once | 'sort'>,
+            Once | 'sort'
+        > {
     /**
      * Matches records where `key` equals `value`.
      *
@@ -840,40 +846,19 @@ export interface QueryBuilder<
             q: QueryBuilder<T, MaxDepth>,
         ) => Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>,
     ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
-    /**
-     * **_Once_** - This can only be used once.
-     *
-     * Sorts the results by the specified keys.
-     *
-     * Prefixes:
-     * - `-`: Descending order.
-     * - `+`: **DEFAULT**. Ascending order.
-     *
-     * Macros:
-     * - `@random`: Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
-     * - `@rowid`: **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
-     *
-     * @example
-     * ```ts
-     * const query = pbQuery<Post>()
-     *    .sort(['title', '-created'])
-     *    .build(pb.filter);
-     *
-     * console.log(query.sort) // Output: 'title,-created'
-     * ```
-     *
-     * @since 0.3.0
-     */
-    sort<P extends PathSort<T, MaxDepth>>(
-        keys: P | P[],
-    ): Omit<QueryBuilder<T, MaxDepth, Once | 'sort'>, Once | 'sort'>
 }
 
 export interface RestrictedQueryBuilder<
     T,
     MaxDepth extends number = 6,
     Once extends keyof QueryBuilder<T, MaxDepth> | '' = '',
-> extends QueryBuilderEnd {
+> extends QueryBuilderEnd,
+        SortMethod<
+            T,
+            MaxDepth,
+            RestrictedQueryBuilder<T, MaxDepth, Once | 'sort'>,
+            Once | 'sort'
+        > {
     /**
      * Combines the previous and the next conditions with an `and` logical operator.
      *
@@ -892,33 +877,6 @@ export interface RestrictedQueryBuilder<
      * ```
      */
     or(): Omit<QueryBuilder<T, MaxDepth, Once>, Once | 'build'>
-    /**
-     * **_Once_** - This can only be used once.
-     *
-     * Sorts the results by the specified keys.
-     *
-     * Prefixes:
-     * - `-`: Descending order.
-     * - `+` (default): Ascending order.
-     *
-     * Macros:
-     * - `@random`: Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
-     * - `@rowid`: **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
-     *
-     * @example
-     * ```ts
-     * const query = pbQuery<Post>()
-     *    .sort(['title', '-created'])
-     *    .build(pb.filter);
-     *
-     * console.log(query.sort) // Output: 'title,-created'
-     * ```
-     *
-     * @since 0.3.0
-     */
-    sort<P extends PathSort<T, MaxDepth>>(
-        keys: P | P[],
-    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once | 'sort'>, Once | 'sort'>
 }
 
 export interface QueryBuilderEnd {
@@ -982,4 +940,37 @@ export interface QueryBuilderEnd {
     build(): QueryResult<RawQueryObject>
     build(filter: FilterFunction): QueryResult<string>
     build(filter?: FilterFunction): QueryResult<RawQueryObject | string>
+}
+
+interface SortMethod<
+    T,
+    MaxDepth extends number,
+    Builder,
+    Once extends PropertyKey,
+> {
+    /**
+     * **_Once_** - This can only be used once.
+     *
+     * Sorts the results by the specified keys.
+     *
+     * Prefixes:
+     * - `-`: Descending order.
+     * - `+` (default): Ascending order.
+     *
+     * Macros:
+     * - `@random`: Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
+     * - `@rowid`: **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
+     *
+     * @example
+     * ```ts
+     * const query = pbQuery<Post>()
+     *    .sort(['title', '-created'])
+     *    .build(pb.filter);
+     *
+     * console.log(query.sort) // Output: 'title,-created'
+     * ```
+     *
+     * @since 0.3.0
+     */
+    sort<P extends PathSort<T, MaxDepth>>(keys: P | P[]): Omit<Builder, Once>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type QueryResult<T = string> = {
     filter: T
     fields: string
     expand: string
+    sort: string
 }
 
 export type GeoPoint = { lon: string; lat: string }
@@ -165,6 +166,51 @@ export type PathFields<
             | '*'
       : never
 
+export type PathSort<
+    T,
+    MaxDepth extends number,
+    K extends keyof T = keyof T,
+    D extends number = 0,
+> = D extends MaxDepth
+    ? never
+    : K extends string // This filters out symbol keys, now K is guaranteed to be string key
+      ? '@random' | '@rowid' | SortKey<PathSortLoop<T, MaxDepth, K, D>>
+      : never
+
+export type PathSortLoop<
+    T,
+    MaxDepth extends number,
+    K extends keyof T = keyof T,
+    D extends number = 0,
+> = D extends MaxDepth
+    ? never
+    : K extends string // This filters out symbol keys, now K is guaranteed to be string key
+      ? PathHelper<
+            T,
+            K,
+            // Text
+            `${K}`,
+            // Date
+            `${K}`,
+            // GeoPoint
+            `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+            // Multiple
+            `${K}`,
+            // Relation
+            | `${K}`
+            | `${K}.${PathSortLoop<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+            | `${string}_via_${string}.${string}`,
+            // Multiple Relation
+            | `${K}`
+            | `${K}.${PathSortLoop<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+            | `${string}_via_${string}.${string}`,
+            // Other
+            `${K}`
+        >
+      : never
+
+type SortKey<K extends string> = `${K}` | `-${K}` | `+${K}`
+
 type PathValueHelper<
     T,
     P extends string,
@@ -235,10 +281,11 @@ export interface QueryBuilderStart<
      *         'expand.author',             // Expanded relation field
      *         'expand.comments_via_post',  // Back-relation expansion
      *     ])
+     *     .sort(['title', 'author'])
      *     .build(pb.filter);
      *
-     * console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
      * console.log(query.expand); // Output: 'author,comments_via_post'
+     * console.log(query.sort);   // Output: 'title,author'
      *
      * const records = await pb.collection('posts').getList(1, 20, query);
      *
@@ -328,8 +375,11 @@ export interface QueryBuilderStart<
     ): Omit<QueryBuilderStart<T, MaxDepth, Once | 'expand'>, Once | 'expand'>
 }
 
-export interface QueryBuilder<T, MaxDepth extends number = 6>
-    extends QueryBuilderEnd {
+export interface QueryBuilder<
+    T,
+    MaxDepth extends number = 6,
+    Once extends keyof QueryBuilder<T, MaxDepth> | '' = '',
+> extends QueryBuilderEnd {
     /**
      * Matches records where `key` equals `value`.
      *
@@ -343,7 +393,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     equal<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` is not equal to `value`.
@@ -358,7 +408,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     notEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` is greater than `value`.
@@ -374,7 +424,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     greaterThan<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` is greater than or equal to `value`.
@@ -390,7 +440,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     greaterThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` is less than `value`.
@@ -406,7 +456,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     lessThan<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` is less than or equal to `value`.
@@ -422,7 +472,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     lessThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` contains `value`.
@@ -448,7 +498,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     like<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Matches records where `key` doesn't contain `value`.
@@ -474,7 +524,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     notLike<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -492,7 +542,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -510,7 +560,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyNotEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -525,7 +575,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyGreaterThan<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -540,7 +590,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyGreaterThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -555,7 +605,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyLessThan<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -570,7 +620,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyLessThanOrEqual<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -598,7 +648,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyLike<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Useful for queries involving [back-relations](https://pocketbase.io/docs/working-with-relations/#back-relations), [multiple relation](https://pocketbase.io/docs/collections/#relationfield), [multiple select](https://pocketbase.io/docs/collections/#selectfield), or [multiple file](https://pocketbase.io/docs/collections/#filefield).
@@ -626,7 +676,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     anyNotLike<P extends Path<T, MaxDepth>>(
         key: P,
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -660,7 +710,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     search<P extends Path<T, MaxDepth>>(
         keys: P[],
         value: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -675,7 +725,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     in<P extends Path<T, MaxDepth>>(
         key: P,
         values: PathValue<T, P, MaxDepth>[],
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -690,7 +740,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     notIn<P extends Path<T, MaxDepth>>(
         key: P,
         values: PathValue<T, P, MaxDepth>[],
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -709,7 +759,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
         key: P,
         from: PathValue<T, P, MaxDepth>,
         to: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -728,7 +778,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
         key: P,
         from: PathValue<T, P, MaxDepth>,
         to: PathValue<T, P, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -742,7 +792,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      */
     isNull<P extends Path<T, MaxDepth>>(
         key: P,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -756,7 +806,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      */
     isNotNull<P extends Path<T, MaxDepth>>(
         key: P,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * **_Helper_**
@@ -775,7 +825,7 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
      * pbQuery<User>().custom(pb.filter('geoDistance(address.lon, address.lat, {:lon}, {:lat}) < {:distance}', { lon: 23.32, lat: 42.69, distance: 25 })); // geoDistance(address.lon, address.lat, 23.32, 42.69) < 25
      * ```
      */
-    custom(raw: string): RestrictedQueryBuilder<T, MaxDepth>
+    custom(raw: string): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 
     /**
      * Creates a logical group.
@@ -788,12 +838,42 @@ export interface QueryBuilder<T, MaxDepth extends number = 6>
     group(
         callback: (
             q: QueryBuilder<T, MaxDepth>,
-        ) => RestrictedQueryBuilder<T, MaxDepth>,
-    ): RestrictedQueryBuilder<T, MaxDepth>
+        ) => Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>,
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
+    /**
+     * **_Once_** - This can only be used once.
+     *
+     * Sorts the results by the specified keys.
+     *
+     * Prefixes:
+     * - `-`: Descending order.
+     * - `+`: **DEFAULT**. Ascending order.
+     *
+     * Macros:
+     * - `@random`: Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
+     * - `@rowid`: **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
+     *
+     * @example
+     * ```ts
+     * const query = pbQuery<Post>()
+     *    .sort(['title', '-created'])
+     *    .build(pb.filter);
+     *
+     * console.log(query.sort) // Output: 'title,-created'
+     * ```
+     *
+     * @since 0.3.0
+     */
+    sort<P extends PathSort<T, MaxDepth>>(
+        keys: P | P[],
+    ): Omit<QueryBuilder<T, MaxDepth, Once | 'sort'>, Once | 'sort'>
 }
 
-export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6>
-    extends QueryBuilderEnd {
+export interface RestrictedQueryBuilder<
+    T,
+    MaxDepth extends number = 6,
+    Once extends keyof QueryBuilder<T, MaxDepth> | '' = '',
+> extends QueryBuilderEnd {
     /**
      * Combines the previous and the next conditions with an `and` logical operator.
      *
@@ -802,7 +882,7 @@ export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6>
      * pbQuery<User>().equal('name', 'Alice').and().equal('role', 'admin'); // name='Alice' && role='admin'
      * ```
      */
-    and(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
+    and(): Omit<QueryBuilder<T, MaxDepth, Once>, Once | 'build'>
     /**
      * Combines the previous and the next conditions with an `or` logical operator.
      *
@@ -811,7 +891,34 @@ export interface RestrictedQueryBuilder<T, MaxDepth extends number = 6>
      * pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
      * ```
      */
-    or(): Omit<QueryBuilder<T, MaxDepth>, 'build'>
+    or(): Omit<QueryBuilder<T, MaxDepth, Once>, Once | 'build'>
+    /**
+     * **_Once_** - This can only be used once.
+     *
+     * Sorts the results by the specified keys.
+     *
+     * Prefixes:
+     * - `-`: Descending order.
+     * - `+` (default): Ascending order.
+     *
+     * Macros:
+     * - `@random`: Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
+     * - `@rowid`: **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).
+     *
+     * @example
+     * ```ts
+     * const query = pbQuery<Post>()
+     *    .sort(['title', '-created'])
+     *    .build(pb.filter);
+     *
+     * console.log(query.sort) // Output: 'title,-created'
+     * ```
+     *
+     * @since 0.3.0
+     */
+    sort<P extends PathSort<T, MaxDepth>>(
+        keys: P | P[],
+    ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once | 'sort'>, Once | 'sort'>
 }
 
 export interface QueryBuilderEnd {
@@ -841,11 +948,13 @@ export interface QueryBuilderEnd {
      *         'expand.comments_via_post',
      *     ]) // Optional
      *     .search(['title', 'content', 'tags', 'author.name'], 'Football')
+     *     .sort(['title', '-created'])
      *     .build(pb.filter);
      *
      * console.log(query.filter); // Output: "(title~'Football' || content~'Football' || tags~'Football' || author.name~'Football')"
      * console.log(query.fields); // Output: 'title,content:excerpt(100,true),author,expand.author,expand.comments_via_post'
      * console.log(query.expand); // Output: 'author,comments_via_post'
+     * console.log(query.sort);   // Output: 'title,-created'
      *
      * const records = await pb.collection('posts').getList(1, 20, query);
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { DATETIME_MACROS } from './constants'
+import type { DATETIME_MACROS, OPERATORS } from './constants'
 
 export type FilterFunction = (
     raw: string,
@@ -8,6 +8,8 @@ export type FilterFunction = (
 ) => string
 
 export type DatetimeMacro = (typeof DATETIME_MACROS)[number]
+export type OperatorMethod = keyof typeof OPERATORS
+export type Operator = (typeof OPERATORS)[OperatorMethod]
 
 export type RawQueryObject = { raw: string; values: Record<string, unknown> }
 export type QueryResult<T = string> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,7 +283,9 @@ export interface QueryBuilderStart<
     /**
      * **_Starter_**, **_Once_** - This can only be used once, at the start.
      *
-     * Select which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
+     * Accepts a single key or an array of keys.
+     *
+     * Selects which fields to return from PocketBase. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations).
      *
      * Modifiers:
      * - `*` targets all keys from the specific depth level.
@@ -348,7 +350,9 @@ export interface QueryBuilderStart<
     /**
      * **_Starter_**, **_Once_** - This can only be used once, at the start.
      *
-     * `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
+     * Accepts a single key or an array of keys.
+     *
+     * Expands information from related collections. `expand()` is not needed if `fields()` is used, we automatically include what to [expand](https://pocketbase.io/docs/working-with-relations/#expanding-relations). If used together with `fields()`, it overrides the automatic expansion.
      *
      * Notes:
      * - Supports up to 6-levels depth nested relations expansion.
@@ -968,6 +972,8 @@ interface SortMethod<
 > {
     /**
      * **_Once_** - This can only be used once.
+     *
+     * Accepts a single key or an array of keys.
      *
      * Sorts the results by the specified keys.
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export type QueryResult<T = string> = {
 
 export type GeoPoint = { lon: string; lat: string }
 
+type SortKey<K extends string> = `${K}` | `-${K}` | `+${K}`
+
 type Exact<T, U, Y = unknown, N = never> = (<G>() => G extends T
     ? 1
     : 2) extends <G>() => G extends U ? 1 : 2
@@ -26,6 +28,40 @@ type Exact<T, U, Y = unknown, N = never> = (<G>() => G extends T
     : N
 
 type DepthCounter = [1, 2, 3, 4, 5, 6, never]
+
+/**
+ * Forces the IDE to display the type alias instead of the full type union.
+ */
+type ForceAlias<T> = T & {}
+
+/**
+ * A lazy way of doing `T[keyof T][number]`.
+ */
+type Elem<T> = T extends readonly (infer U)[] ? U : never
+
+type PathHelper<
+    T,
+    K extends keyof T & string,
+    TextField,
+    DateField,
+    GeoPointField,
+    MultipleField,
+    RelationField,
+    MultipleRelationField,
+    Other,
+> = T[K] extends string
+    ? TextField
+    : T[K] extends readonly object[]
+      ? MultipleRelationField
+      : T[K] extends readonly unknown[]
+        ? MultipleField
+        : T[K] extends Date
+          ? DateField
+          : Exact<T[K], GeoPoint, 1, 2> extends 1
+            ? GeoPointField
+            : T[K] extends object
+              ? RelationField
+              : Other
 
 export type Path<T, MaxDepth extends number> = ForceAlias<FullPath<T, MaxDepth>>
 type FullPath<
@@ -61,40 +97,6 @@ type FullPath<
             `${K}`
         >
       : never
-
-/**
- * Forces the IDE to display the type alias instead of the full type union.
- */
-type ForceAlias<T> = T & {}
-
-/**
- * A lazy way of doing `T[keyof T][number]`.
- */
-type Elem<T> = T extends readonly (infer U)[] ? U : never
-
-type PathHelper<
-    T,
-    K extends keyof T & string,
-    TextField,
-    DateField,
-    GeoPointField,
-    MultipleField,
-    RelationField,
-    MultipleRelationField,
-    Other,
-> = T[K] extends string
-    ? TextField
-    : T[K] extends readonly object[]
-      ? MultipleRelationField
-      : T[K] extends readonly unknown[]
-        ? MultipleField
-        : T[K] extends Date
-          ? DateField
-          : Exact<T[K], GeoPoint, 1, 2> extends 1
-            ? GeoPointField
-            : T[K] extends object
-              ? RelationField
-              : Other
 
 export type PathExpand<T, MaxDepth extends number> = ForceAlias<
     FullPathExpand<T, MaxDepth>
@@ -184,7 +186,7 @@ type FullPathFields<
 export type PathSort<T, MaxDepth extends number> = ForceAlias<
     FullPathSort<T, MaxDepth>
 >
-export type FullPathSort<
+type FullPathSort<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -195,7 +197,7 @@ export type FullPathSort<
       ? '@random' | '@rowid' | SortKey<PathSortLoop<T, MaxDepth, K, D>>
       : never
 
-export type PathSortLoop<
+type PathSortLoop<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -226,8 +228,6 @@ export type PathSortLoop<
             `${K}`
         >
       : never
-
-type SortKey<K extends string> = `${K}` | `-${K}` | `+${K}`
 
 type PathValueHelper<
     T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,8 @@ type Exact<T, U, Y = unknown, N = never> = (<G>() => G extends T
 
 type DepthCounter = [1, 2, 3, 4, 5, 6, never]
 
-export type Path<
+export type Path<T, MaxDepth extends number> = ForceAlias<FullPath<T, MaxDepth>>
+type FullPath<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -43,24 +44,32 @@ export type Path<
             // Date
             `${K}`,
             // GeoPoint
-            `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+            `${K}.${FullPath<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
             // Multiple
             `${K}` | `${K}:each` | `${K}:length`,
             // Relation
             | `${K}`
-            | `${K}.${Path<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+            | `${K}.${FullPath<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
             | `${string}_via_${string}.${string}`,
             // Multiple Relation
             | `${K}`
             | `${K}:each`
             | `${K}:length`
-            | `${K}.${Path<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+            | `${K}.${FullPath<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
             | `${string}_via_${string}.${string}`,
             // Other
             `${K}`
         >
       : never
 
+/**
+ * Forces the IDE to display the type alias instead of the full type union.
+ */
+type ForceAlias<T> = T & {}
+
+/**
+ * A lazy way of doing `T[keyof T][number]`.
+ */
 type Elem<T> = T extends readonly (infer U)[] ? U : never
 
 type PathHelper<
@@ -87,7 +96,10 @@ type PathHelper<
               ? RelationField
               : Other
 
-export type PathExpand<
+export type PathExpand<T, MaxDepth extends number> = ForceAlias<
+    FullPathExpand<T, MaxDepth>
+>
+type FullPathExpand<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -108,12 +120,12 @@ export type PathExpand<
             never,
             // Relation
             | `${K}`
-            | `${K}.${PathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+            | `${K}.${FullPathExpand<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
             | `${string}_via_${string}`
             | `${string}_via_${string}.${string}`,
             // Multiple Relation
             | `${K}`
-            | `${K}.${PathExpand<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+            | `${K}.${FullPathExpand<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
             | `${string}_via_${string}`
             | `${string}_via_${string}.${string}`,
             // Other
@@ -121,7 +133,10 @@ export type PathExpand<
         >
       : never
 
-export type PathFields<
+export type PathFields<T, MaxDepth extends number> = ForceAlias<
+    FullPathFields<T, MaxDepth>
+>
+type FullPathFields<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -141,14 +156,14 @@ export type PathFields<
                   `${K}`,
                   // GeoPoint
                   | `${K}`
-                  | `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+                  | `${K}.${FullPathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
                   // Multiple
                   `${K}`,
                   // Relation
                   | `${K}`
                   | `expand.${K}`
                   | `expand.${K}.*`
-                  | `expand.${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
+                  | `expand.${K}.${FullPathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`
                   | `${string}_via_${string}`
                   | `expand.${string}_via_${string}`
                   | `expand.${string}_via_${string}.${string}`,
@@ -156,7 +171,7 @@ export type PathFields<
                   | `${K}`
                   | `expand.${K}`
                   | `expand.${K}.*`
-                  | `expand.${K}.${PathFields<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
+                  | `expand.${K}.${FullPathFields<Elem<T[K]>, MaxDepth, keyof Elem<T[K]>, DepthCounter[D]>}`
                   | `${string}_via_${string}`
                   | `expand.${string}_via_${string}`
                   | `expand.${string}_via_${string}.${string}`,
@@ -166,7 +181,10 @@ export type PathFields<
             | '*'
       : never
 
-export type PathSort<
+export type PathSort<T, MaxDepth extends number> = ForceAlias<
+    FullPathSort<T, MaxDepth>
+>
+export type FullPathSort<
     T,
     MaxDepth extends number,
     K extends keyof T = keyof T,
@@ -193,7 +211,7 @@ export type PathSortLoop<
             // Date
             `${K}`,
             // GeoPoint
-            `${K}.${PathFields<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
+            `${K}.${PathSortLoop<T[K], MaxDepth, keyof T[K], DepthCounter[D]>}`,
             // Multiple
             `${K}`,
             // Relation

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,3 +106,9 @@ export function generateExpand(keys: string[]) {
         }, [] as string[])
         .join(',')
 }
+
+export function generateSort(keys: string[]) {
+    const uniqueKeys = [...new Set(keys)]
+
+    return uniqueKeys.join(',')
+}

--- a/tests/query.test-d.ts
+++ b/tests/query.test-d.ts
@@ -85,4 +85,8 @@ test('all possible keys', () => {
 
     expectTypeOf<'anything_via_user'>().not.toMatchTypeOf<Path<Post, 6>>()
     equal('anything_via_user.anything', new Date()).build()
+
+    expectTypeOf<'user'>().toMatchTypeOf<Path<Post, 1>>()
+    expectTypeOf<'user.name'>().not.toMatchTypeOf<Path<Post, 1>>()
+    expectTypeOf<'user.name'>().toMatchTypeOf<Path<Post, 2>>()
 })

--- a/tests/query.test-d.ts
+++ b/tests/query.test-d.ts
@@ -89,4 +89,15 @@ test('all possible keys', () => {
     expectTypeOf<'user'>().toMatchTypeOf<Path<Post, 1>>()
     expectTypeOf<'user.name'>().not.toMatchTypeOf<Path<Post, 1>>()
     expectTypeOf<'user.name'>().toMatchTypeOf<Path<Post, 2>>()
+
+    const test1 = pbQuery<Post>().equal('id', 'test')
+    expectTypeOf<'sort'>().toMatchTypeOf<keyof typeof test1>()
+
+    const test2 = pbQuery<Post>().sort(['-created']).equal('id', 'test')
+    expectTypeOf<'and'>().toMatchTypeOf<keyof typeof test2>()
+    expectTypeOf<'sort'>().not.toMatchTypeOf<keyof typeof test2>()
+
+    const test3 = pbQuery<Post>().sort(['-created']).equal('id', 'test').and()
+    expectTypeOf<'equal'>().toMatchTypeOf<keyof typeof test3>()
+    expectTypeOf<'sort'>().not.toMatchTypeOf<keyof typeof test3>()
 })

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -285,3 +285,49 @@ test('expand', () => {
     const query3 = pbQuery<Post>().expand('author').build(filter)
     expect(query3.expand).toBe(['author'].join(','))
 })
+
+test('sort', () => {
+    const query1 = pbQuery<Post>()
+        .sort([
+            '@random',
+            '@rowid',
+            'related.updated',
+            'related.updated',
+            'author',
+            '+author',
+            '-created',
+        ])
+        .equal('author', 'a')
+        .or()
+        .equal('author', 'a')
+        .build(filter)
+    expect(query1.sort).toBe(
+        [
+            '@random',
+            '@rowid',
+            'related.updated',
+            'author',
+            '+author',
+            '-created',
+        ].join(','),
+    )
+
+    const query2 = pbQuery<Post>()
+        .equal('author', 'a')
+        .sort(['-created'])
+        .or()
+        .equal('author', 'a')
+        .build(filter)
+    expect(query2.sort).toBe(['-created'].join(','))
+
+    const query3 = pbQuery<Post>()
+        .equal('author', 'a')
+        .or()
+        .sort(['-created'])
+        .equal('author', 'a')
+        .build(filter)
+    expect(query3.sort).toBe(['-created'].join(','))
+
+    const query4 = pbQuery<Post>().sort('-created').build(filter)
+    expect(query4.sort).toBe(['-created'].join(','))
+})


### PR DESCRIPTION
**_Once_** - This can only be used once.

Accepts a single key or an array of keys.

Sorts the results by the specified keys.

Prefixes:
- `-` – Descending order.
- `+` – **DEFAULT**. Ascending order.

Macros:
- `@random` – Orders by [sqlite's random() function](https://sqlite.org/lang_corefunc.html#random). Useful for shuffling results.
- `@rowid` – **NOT THE SAME AS `id`**. Orders by [sqlite's internal `rowid`](https://www.sqlite.org/lang_createtable.html#rowid). [Can't](https://www.sqlite.org/rowidtable.html) be used with [View Collections](https://pocketbase.io/docs/collections/#view-collection).

```ts
const query = pbQuery<Post>()
   .sort(['title', '-created'])
   .build(pb.filter);

console.log(query.sort) // Output: 'title,-created'
```