### PR TITLE
Allow the use of trailing logical operators and clean the query before returning it

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -11,6 +11,7 @@ import type {
     RestrictedQueryBuilder,
 } from './types'
 import {
+    cleanQuery,
     generateExpand,
     generateFields,
     generateSort,
@@ -84,18 +85,20 @@ export function pbQuery<
     function build(
         filter?: FilterFunction,
     ): QueryResult<RawQueryObject | string> {
+        const cleanedQuery = cleanQuery(query)
+
         if (typeof filter === 'function') {
             return {
                 expand,
                 fields,
-                filter: filter(query, Object.fromEntries(valueMap)),
+                filter: filter(cleanedQuery, Object.fromEntries(valueMap)),
                 sort,
             }
         }
         return {
             expand,
             fields,
-            filter: { raw: query, values: Object.fromEntries(valueMap) },
+            filter: { raw: cleanedQuery, values: Object.fromEntries(valueMap) },
             sort,
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -862,7 +862,9 @@ export interface QueryBuilder<
     group(
         callback: (
             q: QueryBuilder<T, MaxDepth>,
-        ) => Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>,
+        ) =>
+            | Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
+            | Omit<QueryBuilder<T, MaxDepth, Once>, Once>,
     ): Omit<RestrictedQueryBuilder<T, MaxDepth, Once>, Once>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -887,7 +887,7 @@ export interface RestrictedQueryBuilder<
      * pbQuery<User>().equal('name', 'Alice').and().equal('role', 'admin'); // name='Alice' && role='admin'
      * ```
      */
-    and(): Omit<QueryBuilder<T, MaxDepth, Once>, Once | 'build'>
+    and(): Omit<QueryBuilder<T, MaxDepth, Once>, Once>
     /**
      * Combines the previous and the next conditions with an `or` logical operator.
      *
@@ -896,7 +896,7 @@ export interface RestrictedQueryBuilder<
      * pbQuery<User>().equal('name', 'Alice').or().equal('name', 'Bob'); // name='Alice' || name='Bob'
      * ```
      */
-    or(): Omit<QueryBuilder<T, MaxDepth, Once>, Once | 'build'>
+    or(): Omit<QueryBuilder<T, MaxDepth, Once>, Once>
 }
 
 export interface QueryBuilderEnd {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,3 +112,45 @@ export function generateSort(keys: string[]) {
 
     return uniqueKeys.join(',')
 }
+
+export function cleanQuery(query: string): string {
+    if (!query?.trim()) return query || ''
+
+    const steps = [
+        removeOperatorsAfterOpeningParenthesis,
+        removeOperatorsBeforeClosingParenthesis,
+        removeStackedOperators,
+        removeTrailingOperators,
+        normalize,
+    ]
+
+    return steps.reduce((result, step) => step(result), query)
+}
+
+const AND = '&&'
+const OR = '\\|\\|' // escaped because of regex
+const OP = `(?:${AND}|${OR})` // matches && or ||
+const OP_SEQ = `${OP}(?:\\s*${OP})*` // matches sequences like "|| && && ||"
+
+function normalize(str: string): string {
+    return str.replace(/\s+/g, ' ').trim()
+}
+
+function removeOperatorsAfterOpeningParenthesis(str: string): string {
+    // Remove ANY sequence of operators right after "("
+    return str.replace(new RegExp(`\\(\\s*${OP_SEQ}\\s*`, 'g'), '(')
+}
+
+function removeOperatorsBeforeClosingParenthesis(str: string): string {
+    // Remove ANY sequence of operators right before ")"
+    return str.replace(new RegExp(`\\s*${OP_SEQ}\\s*\\)`, 'g'), ')')
+}
+
+function removeStackedOperators(str: string): string {
+    // "&& &&", "|| ||", "&& ||", etc.
+    return str.replace(new RegExp(`${OP}\\s+${OP}`, 'g'), '')
+}
+
+function removeTrailingOperators(str: string): string {
+    return str.replace(new RegExp(`${OP}\\s*$`, 'g'), '')
+}

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -2,7 +2,7 @@ import PocketBase from 'pocketbase'
 import { expect, test } from 'vitest'
 import { pbQuery } from '../src/query'
 import type { GeoPoint } from '../src/types'
-import { filter } from '../src/utils'
+import { cleanQuery, filter } from '../src/utils'
 
 interface User {
     id: string
@@ -338,4 +338,36 @@ test('sort', () => {
 
     const query4 = pbQuery<Post>().sort('-created').build(filter)
     expect(query4.sort).toBe(['-created'].join(','))
+})
+
+test('query cleanup', () => {
+    const rawQuery =
+        "&& || name='test1' && (|| &&name='test2'    ||   && ) && id='test3' && || "
+
+    const cleanedQuery = cleanQuery(rawQuery)
+    expect(cleanedQuery).toBe("name='test1' && (name='test2') && id='test3'")
+
+    const condition1 = true
+    const candition2 = false
+
+    const query = pbQuery<User>()
+        .custom(rawQuery)
+        .and()
+        .group((q) => {
+            if (condition1) {
+                q.equal('city', 'New York').or()
+            }
+
+            if (candition2) {
+                q.equal('age', 30).or()
+            }
+
+            return q
+        })
+
+    query.and()
+
+    expect(query.build(filter).filter).toBe(
+        "name='test1' && (name='test2') && id='test3' && (city='New York')",
+    )
 })


### PR DESCRIPTION
This change should make it easier to build dynamic queries.

Example 1:

```ts
const query = pbQuery<User>()
    .group((q) => {
        if (condition1) { // true
            q.equal('name', 'Sergio').or()
        }

        if (condition2) { // true
            q.equal('city', 'New York').or()
        }

        if (candition3) { // false
            q.equal('age', 30).or()
        }

        return q
    })
    .build(pb.filter)

console.log(query.filter)
// Output: "(name='Sergio' || city='New York')"
```

Example 2:

```ts
const query = pbQuery<User>().equal('name', 'Sergio').and()

query.equal('city', 'New York').and() // trailing logical operator

console.log(query.build(pb.filter).filter)
// Output: "name='Sergio' && city='New York'"
```